### PR TITLE
set alphabets from data or pipe when reading serialised instance list

### DIFF
--- a/src/cc/mallet/types/InstanceList.java
+++ b/src/cc/mallet/types/InstanceList.java
@@ -831,6 +831,22 @@ public InstanceList[] splitInOrder (double[] proportions) {
 		int version = in.readInt ();
 		instWeights = (HashMap<Instance,Double>) in.readObject();
 		pipe = (Pipe) in.readObject();
+		if (dataAlphabet == null) {
+			if (size()>0) { 
+				Instance instance = get(0); 
+				dataAlphabet = instance.getDataAlphabet (); 
+			}  else if (pipe.getDataAlphabet()!=null) {
+				dataAlphabet = pipe.getDataAlphabet ();
+			}
+		}
+		if (targetAlphabet == null) {
+			if (size()>0) { 
+				Instance instance = get(0); 
+				targetAlphabet = instance.getTargetAlphabet (); 
+			}  else if (pipe.getTargetAlphabet()!=null) {
+				targetAlphabet = pipe.getTargetAlphabet ();
+			}
+		}
 	}
 
 	// added - culotta@cs.umass.edu


### PR DESCRIPTION
If an InstanceList which doesn't have a pipe (ie: has a `Noop` pipe) is serialised and read back in then `getAlphabet()` returns `null`.

The problem is that `InstanceList.readObject()` doesn't explicitly setup the Alphabet. The `getAlphabet()` methods in `InstanceList` check if the Alphabets have been set, and if not, look for them in the pipe. Alphabets are normally set from instance alphabets when instances are `add()`'ed to the list. When a serialised `InstanceList` is read, the alphabets havn't been set by `add()`, and if the pipe has no alphabets, we have a problem! 

This patch that works for me, but in hindsight it may be better to change the `getAlphabet()` methods to check for an `Alphabet` in the stored instances before looking in the pipe.
