### PR TITLE
SparseVector: got rid of NPE when getting value for null indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 class
 dist/mallet-deps.jar
 dist/mallet.jar
+/target/
+.classpath
+.project
+.settings/
+*.obj
+*.dot

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>cc.mallet</groupId>
   <artifactId>mallet</artifactId>
-  <version>2.0.8-SNAPSHOT</version>
+  <version>2.0.9-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>MAchine Learning for LanguagE Toolkit (MALLET)</name>
   <description>

--- a/src/cc/mallet/types/SparseVector.java
+++ b/src/cc/mallet/types/SparseVector.java
@@ -284,7 +284,7 @@ public class SparseVector implements ConstantMatrix, Vector, Serializable
 	{
 		assert (indices.length == 1);
 		if (indices == null)
-			return values[indices[0]];
+			return values[this.indices[0]];
 		else
 			return values[location(indices[0])];
 	}


### PR DESCRIPTION
BTW is it normal that almost 100 tests fail or have errors when running with Maven?
