### PR TITLE
Fix bug in LineIterator

### DIFF
--- a/src/cc/mallet/pipe/iterator/LineIterator.java
+++ b/src/cc/mallet/pipe/iterator/LineIterator.java
@@ -33,6 +33,7 @@ public class LineIterator implements Iterator<Instance>
 		this.lineRegex = lineRegex;
 		this.targetGroup = targetGroup;
 		this.dataGroup = dataGroup;
+		this.uriGroup = uriGroup;
 		if (dataGroup < 0)
 			throw new IllegalStateException ("You must extract a data field.");
 		try {


### PR DESCRIPTION
uriGroup passed in was always discarded