### PR TITLE
Trove 2 -> 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,10 @@
       <artifactId>jwnl</artifactId>
       <version>1.4_rc3</version>
     </dependency>
-    <dependency>
+     <dependency>
       <groupId>net.sf.trove4j</groupId>
       <artifactId>trove4j</artifactId>
-      <version>2.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.matrix-toolkits-java</groupId>

--- a/src/cc/mallet/classify/constraints/ge/MaxEntFLGEConstraints.java
+++ b/src/cc/mallet/classify/constraints/ge/MaxEntFLGEConstraints.java
@@ -7,9 +7,9 @@
 
 package cc.mallet.classify.constraints.ge;
 
-import gnu.trove.TDoubleArrayList;
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.BitSet;
 

--- a/src/cc/mallet/classify/constraints/ge/MaxEntRangeL2FLGEConstraints.java
+++ b/src/cc/mallet/classify/constraints/ge/MaxEntRangeL2FLGEConstraints.java
@@ -7,17 +7,16 @@
 
 package cc.mallet.classify.constraints.ge;
 
-import gnu.trove.TDoubleArrayList;
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntObjectHashMap;
+import cc.mallet.types.FeatureVector;
+import cc.mallet.types.Instance;
+import cc.mallet.types.InstanceList;
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
-
-import cc.mallet.types.FeatureVector;
-import cc.mallet.types.Instance;
-import cc.mallet.types.InstanceList;
 
 /**
  * Expectation constraint for use with GE.

--- a/src/cc/mallet/classify/constraints/pr/MaxEntFLPRConstraints.java
+++ b/src/cc/mallet/classify/constraints/pr/MaxEntFLPRConstraints.java
@@ -7,15 +7,14 @@
 
 package cc.mallet.classify.constraints.pr;
 
-import gnu.trove.TDoubleArrayList;
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntObjectHashMap;
-
-import java.util.BitSet;
-
 import cc.mallet.types.FeatureVector;
 import cc.mallet.types.Instance;
 import cc.mallet.types.InstanceList;
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntObjectHashMap;
+
+import java.util.BitSet;
 
 /**
  * Abstract expectation constraint for use with Posterior Regularization (PR).

--- a/src/cc/mallet/classify/constraints/pr/MaxEntL2FLPRConstraints.java
+++ b/src/cc/mallet/classify/constraints/pr/MaxEntL2FLPRConstraints.java
@@ -7,7 +7,7 @@
 
 package cc.mallet.classify.constraints.pr;
 
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 import cc.mallet.types.FeatureVector;
 
 /**

--- a/src/cc/mallet/cluster/GreedyAgglomerativeByDensity.java
+++ b/src/cc/mallet/cluster/GreedyAgglomerativeByDensity.java
@@ -1,14 +1,13 @@
 package cc.mallet.cluster;
 
-import java.util.logging.Logger;
-
 import cc.mallet.cluster.neighbor_evaluator.NeighborEvaluator;
 import cc.mallet.cluster.util.ClusterUtils;
 import cc.mallet.pipe.Pipe;
 import cc.mallet.types.Instance;
 import cc.mallet.util.MalletProgressMessageLogger;
+import gnu.trove.list.array.TIntArrayList;
 
-import gnu.trove.TIntArrayList;
+import java.util.logging.Logger;
 
 /**
  * Greedily merges Instances until convergence. New merges are scored
@@ -135,8 +134,9 @@ public class GreedyAgglomerativeByDensity extends GreedyAgglomerative {
 	private void sampleNextInstanceToCluster (Clustering clustering) {
 		if (unclusteredInstances == null)
 			fillUnclusteredInstances(clustering.getNumInstances());
+                
 		instanceBeingClustered = (unclusteredInstances.size() == 0) ? -1 :
-														 unclusteredInstances.remove(0);		
+                    unclusteredInstances.removeAt(0);		
 	}
 
 	private void fillUnclusteredInstances (int size) {

--- a/src/cc/mallet/cluster/Record.java
+++ b/src/cc/mallet/cluster/Record.java
@@ -1,6 +1,6 @@
 package cc.mallet.cluster;
 
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.io.Serializable;
 

--- a/src/cc/mallet/cluster/tui/Clusterings2Clusterings.java
+++ b/src/cc/mallet/cluster/tui/Clusterings2Clusterings.java
@@ -1,6 +1,6 @@
 package cc.mallet.cluster.tui;
 
-import gnu.trove.TIntHashSet;
+import gnu.trove.set.hash.TIntHashSet;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/cc/mallet/cluster/tui/Text2Clusterings.java
+++ b/src/cc/mallet/cluster/tui/Text2Clusterings.java
@@ -1,6 +1,6 @@
 package cc.mallet.cluster.tui;
 
-import gnu.trove.TIntArrayList;
+import gnu.trove.list.array.TIntArrayList;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -71,8 +71,9 @@ public class Text2Clusterings {
 												record.toString()));
 				}
 			}
+                        
 			clusterings[i] =
-					new Clustering(instances, subdirs.length, labels.toNativeArray());
+					new Clustering(instances, subdirs.length, labels.toArray());
 		}
 
 		logger.info("\nread " + fi + " objects in " + clusterings.length + " clusterings.");

--- a/src/cc/mallet/extract/DocumentExtraction.java
+++ b/src/cc/mallet/extract/DocumentExtraction.java
@@ -6,13 +6,16 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.extract;
 
-import org.jdom.Element;
+import cc.mallet.types.Label;
+import cc.mallet.types.LabelAlphabet;
+import cc.mallet.types.LabelSequence;
+import cc.mallet.types.Sequence;
+import gnu.trove.map.hash.THashMap;
 import org.jdom.Document;
+import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.Text;
 import org.jdom.output.XMLOutputter;
-
-import cc.mallet.types.*;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -22,8 +25,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
-import gnu.trove.THashMap;
 
 /**
  * Created: Oct 12, 2004

--- a/src/cc/mallet/extract/Record.java
+++ b/src/cc/mallet/extract/Record.java
@@ -6,7 +6,7 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.extract;
 
-import gnu.trove.THashMap;
+import gnu.trove.map.hash.THashMap;
 
 import java.util.Iterator;
 

--- a/src/cc/mallet/fst/FeatureTransducer.java
+++ b/src/cc/mallet/fst/FeatureTransducer.java
@@ -14,16 +14,16 @@
 
 package cc.mallet.fst;
 
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.Multinomial;
+import cc.mallet.types.Sequence;
+import cc.mallet.util.MalletLogger;
+import gnu.trove.map.hash.TIntObjectHashMap;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.logging.Logger;
-
-import cc.mallet.types.Alphabet;
-import cc.mallet.types.Multinomial;
-import cc.mallet.types.Sequence;
-
-import cc.mallet.util.MalletLogger;
 
 public class FeatureTransducer extends Transducer
 {
@@ -143,7 +143,7 @@ public class FeatureTransducer extends Transducer
 		int index;
 		double initialWeight, finalWeight;
 		Transition[] transitions;
-		gnu.trove.TIntObjectHashMap input2transitions;
+		TIntObjectHashMap input2transitions;
 		Multinomial.Estimator transitionCounts;
 		FeatureTransducer transducer;
 
@@ -161,7 +161,7 @@ public class FeatureTransducer extends Transducer
 			this.initialWeight = initialWeight;
 			this.finalWeight = finalWeight;
 			this.transitions = new Transition[inputs.length];
-			this.input2transitions = new gnu.trove.TIntObjectHashMap ();
+			this.input2transitions = new TIntObjectHashMap ();
 			transitionCounts = null;
 			for (int i = 0; i < inputs.length; i++) {
 				// This constructor places the transtion into this.input2transitions

--- a/src/cc/mallet/fst/semi_supervised/constraints/OneLabelGEConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/constraints/OneLabelGEConstraints.java
@@ -7,8 +7,8 @@
 
 package cc.mallet.fst.semi_supervised.constraints;
 
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.ArrayList;
 import java.util.BitSet;

--- a/src/cc/mallet/fst/semi_supervised/constraints/OneLabelKLGEConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/constraints/OneLabelKLGEConstraints.java
@@ -7,7 +7,7 @@
 
 package cc.mallet.fst.semi_supervised.constraints;
 
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import cc.mallet.fst.semi_supervised.StateLabelMap;
 import cc.mallet.types.MatrixOps;

--- a/src/cc/mallet/fst/semi_supervised/constraints/OneLabelL2GEConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/constraints/OneLabelL2GEConstraints.java
@@ -7,7 +7,7 @@
 
 package cc.mallet.fst.semi_supervised.constraints;
 
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import cc.mallet.fst.semi_supervised.StateLabelMap;
 

--- a/src/cc/mallet/fst/semi_supervised/constraints/OneLabelL2RangeGEConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/constraints/OneLabelL2RangeGEConstraints.java
@@ -7,8 +7,8 @@
 
 package cc.mallet.fst.semi_supervised.constraints;
 
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.ArrayList;
 import java.util.BitSet;

--- a/src/cc/mallet/fst/semi_supervised/constraints/TwoLabelGEConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/constraints/TwoLabelGEConstraints.java
@@ -7,8 +7,8 @@
 
 package cc.mallet.fst.semi_supervised.constraints;
 
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 import java.util.ArrayList;
 import java.util.BitSet;

--- a/src/cc/mallet/fst/semi_supervised/constraints/TwoLabelKLGEConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/constraints/TwoLabelKLGEConstraints.java
@@ -9,7 +9,7 @@ package cc.mallet.fst.semi_supervised.constraints;
 
 import java.util.ArrayList;
 
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 import cc.mallet.fst.semi_supervised.StateLabelMap;
 
 /** 

--- a/src/cc/mallet/fst/semi_supervised/constraints/TwoLabelL2GEConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/constraints/TwoLabelL2GEConstraints.java
@@ -9,7 +9,7 @@ package cc.mallet.fst.semi_supervised.constraints;
 
 import java.util.ArrayList;
 
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 import cc.mallet.fst.semi_supervised.StateLabelMap;
 

--- a/src/cc/mallet/fst/semi_supervised/pr/constraints/OneLabelL2IndPRConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/pr/constraints/OneLabelL2IndPRConstraints.java
@@ -7,8 +7,8 @@
 
 package cc.mallet.fst.semi_supervised.pr.constraints;
 
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.ArrayList;
 import java.util.BitSet;

--- a/src/cc/mallet/fst/semi_supervised/pr/constraints/OneLabelL2PRConstraints.java
+++ b/src/cc/mallet/fst/semi_supervised/pr/constraints/OneLabelL2PRConstraints.java
@@ -7,9 +7,9 @@
 
 package cc.mallet.fst.semi_supervised.pr.constraints;
 
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntIntHashMap;
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.BitSet;
 import cc.mallet.fst.semi_supervised.StateLabelMap;

--- a/src/cc/mallet/grmm/inference/JunctionTree.java
+++ b/src/cc/mallet/grmm/inference/JunctionTree.java
@@ -17,9 +17,9 @@ import java.util.Arrays;
 
 import cc.mallet.grmm.types.*;
 
-import gnu.trove.TIntObjectHashMap;
-import gnu.trove.THashSet;
-import gnu.trove.TIntObjectIterator;
+import gnu.trove.map.hash.TIntObjectHashMap;
+import gnu.trove.set.hash.THashSet;
+import gnu.trove.iterator.TIntObjectIterator;
 
 
 /**

--- a/src/cc/mallet/grmm/inference/MessageArray.java
+++ b/src/cc/mallet/grmm/inference/MessageArray.java
@@ -6,7 +6,7 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.inference;
 
-import gnu.trove.TIntObjectIterator;
+import gnu.trove.iterator.TIntObjectIterator;
 
 import java.io.PrintWriter;
 import java.io.OutputStreamWriter;

--- a/src/cc/mallet/grmm/inference/TRP.java
+++ b/src/cc/mallet/grmm/inference/TRP.java
@@ -7,27 +7,25 @@
 
 package cc.mallet.grmm.inference;
 
-import gnu.trove.THashSet;
-import gnu.trove.THashMap;
-import gnu.trove.TIntObjectHashMap;
-
-import java.util.logging.Logger;
-import java.util.logging.Level;
-import java.util.*;
-import java.io.*;
-
-import org._3pq.jgrapht.UndirectedGraph;
-import org._3pq.jgrapht.Graph;
-import org._3pq.jgrapht.Edge;
-import org._3pq.jgrapht.traverse.BreadthFirstIterator;
-import org._3pq.jgrapht.graph.SimpleGraph;
-import org.jdom.Document;
-import org.jdom.JDOMException;
-import org.jdom.Element;
-import org.jdom.input.SAXBuilder;
-
 import cc.mallet.grmm.types.*;
 import cc.mallet.util.MalletLogger;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
+import gnu.trove.set.hash.THashSet;
+import org._3pq.jgrapht.Edge;
+import org._3pq.jgrapht.Graph;
+import org._3pq.jgrapht.UndirectedGraph;
+import org._3pq.jgrapht.graph.SimpleGraph;
+import org._3pq.jgrapht.traverse.BreadthFirstIterator;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Implementation of Wainwright's TRP schedule for loopy BP

--- a/src/cc/mallet/grmm/inference/TreeBP.java
+++ b/src/cc/mallet/grmm/inference/TreeBP.java
@@ -6,13 +6,12 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.inference;
 
-import gnu.trove.THashSet;
-
-import java.util.Iterator;
-
 import cc.mallet.grmm.types.Factor;
 import cc.mallet.grmm.types.FactorGraph;
 import cc.mallet.grmm.types.Variable;
+import gnu.trove.set.hash.THashSet;
+
+import java.util.Iterator;
 
 /**
  * Implements the tree-based schedule of belief propagation for exact inference

--- a/src/cc/mallet/grmm/inference/Utils.java
+++ b/src/cc/mallet/grmm/inference/Utils.java
@@ -12,7 +12,7 @@ import java.util.Iterator;
 import cc.mallet.grmm.types.*;
 import cc.mallet.types.MatrixOps;
 
-import gnu.trove.THashSet;
+import gnu.trove.set.hash.THashSet;
 
 /**
  * A bunch of static utilities useful for dealing with Inferencers.

--- a/src/cc/mallet/grmm/inference/gbp/FactorizedRegion.java
+++ b/src/cc/mallet/grmm/inference/gbp/FactorizedRegion.java
@@ -7,16 +7,16 @@
 package cc.mallet.grmm.inference.gbp;
 
 
-import java.util.List;
-import java.util.Iterator;
-import java.util.Collection;
-import java.util.Set;
-
 import cc.mallet.grmm.types.Factor;
 import cc.mallet.grmm.types.FactorGraph;
 import cc.mallet.grmm.types.Variable;
+import gnu.trove.set.hash.THashSet;
 
-import gnu.trove.THashSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
 
 /**
  * A more space-efficient Region class that doesn't maintain a global factor
@@ -43,7 +43,7 @@ public class FactorizedRegion extends Region {
 
   private static Collection varsForFactors (List factors)
   {
-    Set vars = new THashSet ();
+    Set vars = new THashSet();
     for (Iterator it = factors.iterator (); it.hasNext ();) {
       Factor ptl = (Factor) it.next ();
       vars.addAll (ptl.varSet ());

--- a/src/cc/mallet/grmm/inference/gbp/Region.java
+++ b/src/cc/mallet/grmm/inference/gbp/Region.java
@@ -12,7 +12,7 @@ import java.util.*;
 import cc.mallet.grmm.types.Factor;
 import cc.mallet.grmm.types.Variable;
 
-import gnu.trove.THashSet;
+import gnu.trove.set.hash.THashSet;
 
 /**
  * Created: May 27, 2005

--- a/src/cc/mallet/grmm/inference/gbp/RegionGraph.java
+++ b/src/cc/mallet/grmm/inference/gbp/RegionGraph.java
@@ -6,13 +6,12 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.inference.gbp;
 
-import gnu.trove.THashSet;
-
-import java.util.*;
-
 import cc.mallet.grmm.types.Factor;
 import cc.mallet.grmm.types.VarSet;
 import cc.mallet.grmm.types.Variable;
+import gnu.trove.set.hash.THashSet;
+
+import java.util.*;
 
 
 /**

--- a/src/cc/mallet/grmm/learning/ACRF.java
+++ b/src/cc/mallet/grmm/learning/ACRF.java
@@ -7,22 +7,10 @@
 
 package cc.mallet.grmm.learning;
 
-import java.util.logging.Logger;
-
-
-
-import java.io.*;
-
-import java.util.*;
-import java.util.regex.Pattern;
-
-import gnu.trove.*;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.input.SAXBuilder;
-
-import cc.mallet.grmm.inference.*;
+import cc.mallet.grmm.inference.AbstractBeliefPropagation;
+import cc.mallet.grmm.inference.Inferencer;
+import cc.mallet.grmm.inference.JunctionTreeInferencer;
+import cc.mallet.grmm.inference.TRP;
 import cc.mallet.grmm.types.*;
 import cc.mallet.grmm.util.LabelsAssignment;
 import cc.mallet.grmm.util.Models;
@@ -31,6 +19,19 @@ import cc.mallet.pipe.Pipe;
 import cc.mallet.types.*;
 import cc.mallet.util.ArrayUtils;
 import cc.mallet.util.MalletLogger;
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TObjectIntHashMap;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 
 /**
@@ -797,7 +798,7 @@ public class ACRF implements Serializable {
         residTmp.add (Factors.distLinf (unif, ptl));
       }
 
-      lastResids = residTmp.toNativeArray ();
+      lastResids = residTmp.toArray ();
     }
 
     /** Adds FACTOR to this graph, but while maintaining the invariant that every set of variables has
@@ -1990,7 +1991,7 @@ public class ACRF implements Serializable {
       idxs.add (idx);
       vals.add (val);
     }
-    return new SparseVector (idxs.toNativeArray (), vals.toNativeArray ());
+    return new SparseVector (idxs.toArray (), vals.toArray ());
   }
 
   public void writeWeightsText (Writer writer)

--- a/src/cc/mallet/grmm/learning/DefaultAcrfTrainer.java
+++ b/src/cc/mallet/grmm/learning/DefaultAcrfTrainer.java
@@ -7,7 +7,7 @@
 
 package cc.mallet.grmm.learning;
 
-import gnu.trove.TIntArrayList;
+import gnu.trove.list.array.TIntArrayList;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/src/cc/mallet/grmm/learning/PseudolikelihoodACRFTrainer.java
+++ b/src/cc/mallet/grmm/learning/PseudolikelihoodACRFTrainer.java
@@ -8,13 +8,13 @@ package cc.mallet.grmm.learning;
 
 
 import cc.mallet.grmm.types.*;
+import cc.mallet.grmm.util.CachingOptimizable;
 import cc.mallet.optimize.Optimizable;
 import cc.mallet.types.Instance;
 import cc.mallet.types.InstanceList;
 import cc.mallet.types.SparseVector;
 import cc.mallet.util.MalletLogger;
-import cc.mallet.grmm.util.CachingOptimizable;
-import gnu.trove.THashMap;
+import gnu.trove.map.hash.THashMap;
 
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/src/cc/mallet/grmm/learning/templates/SimilarTokensTemplate.java
+++ b/src/cc/mallet/grmm/learning/templates/SimilarTokensTemplate.java
@@ -6,7 +6,7 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.learning.templates;
 
-import gnu.trove.THashMap;
+import gnu.trove.map.hash.THashMap;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/src/cc/mallet/grmm/test/TestBetaFactor.java
+++ b/src/cc/mallet/grmm/test/TestBetaFactor.java
@@ -6,18 +6,17 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.test;
 
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import gnu.trove.TDoubleArrayList;
-
-import java.io.IOException;
-import java.io.BufferedReader;
-import java.io.StringReader;
-
 import cc.mallet.grmm.types.*;
 import cc.mallet.grmm.util.ModelReader;
 import cc.mallet.types.MatrixOps;
 import cc.mallet.util.Randoms;
+import gnu.trove.list.array.TDoubleArrayList;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
 
 /**
  * $Id: TestBetaFactor.java,v 1.1 2007/10/22 21:37:41 mccallum Exp $
@@ -56,7 +55,7 @@ public class TestBetaFactor extends TestCase {
       lst.add (assn.getDouble (var));
     }
 
-    double[] vals = lst.toNativeArray ();
+    double[] vals = lst.toArray ();
     double mean = MatrixOps.mean (vals);
     assertEquals (0.7 / (0.5 + 0.7), mean, 0.01);
   }
@@ -73,7 +72,7 @@ public class TestBetaFactor extends TestCase {
       lst.add (assn.getDouble (var));
     }
 
-    double[] vals = lst.toNativeArray ();
+    double[] vals = lst.toArray ();
     double mean = MatrixOps.mean (vals);
     assertEquals (5.92, mean, 0.01);
   }

--- a/src/cc/mallet/grmm/test/TestInference.java
+++ b/src/cc/mallet/grmm/test/TestInference.java
@@ -7,18 +7,6 @@
 
 package cc.mallet.grmm.test;
 
-import junit.framework.AssertionFailedError;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
-import java.util.*;
-import java.util.Random;
-import java.util.logging.Logger;
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.BufferedReader;
-
 import cc.mallet.grmm.inference.*;
 import cc.mallet.grmm.types.*;
 import cc.mallet.grmm.util.GeneralUtils;
@@ -27,10 +15,22 @@ import cc.mallet.types.Dirichlet;
 import cc.mallet.types.Matrix;
 import cc.mallet.types.Matrixn;
 import cc.mallet.types.tests.TestSerializable;
-import cc.mallet.util.*;
-//import cc.mallet.util.Random;
+import cc.mallet.util.CollectionUtils;
+import cc.mallet.util.MalletLogger;
+import cc.mallet.util.Maths;
+import cc.mallet.util.Timing;
+import gnu.trove.list.array.TDoubleArrayList;
+import junit.framework.AssertionFailedError;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
-import gnu.trove.TDoubleArrayList;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.*;
+import java.util.logging.Logger;
+//import cc.mallet.util.Random;
 
 
 /**
@@ -1251,7 +1251,7 @@ public void testJtConsistency() {
     double[] pA = dirichlet.randomVector (random);
     double[] pB = dirichlet.randomVector (random);
 
-    TDoubleArrayList pC = new TDoubleArrayList (NUM_OUTCOMES * NUM_OUTCOMES * NUM_OUTCOMES);
+    TDoubleArrayList pC = new TDoubleArrayList(NUM_OUTCOMES * NUM_OUTCOMES * NUM_OUTCOMES);
     for (int i = 0; i < (NUM_OUTCOMES * NUM_OUTCOMES); i++) {
       pC.add (dirichlet.randomVector (random));
     }
@@ -1261,7 +1261,7 @@ public void testJtConsistency() {
     DirectedModel mdl = new DirectedModel ();
     mdl.addFactor (new CPT (new TableFactor (vars[0], pA), vars[0]));
     mdl.addFactor (new CPT (new TableFactor (vars[1], pB), vars[1]));
-    mdl.addFactor (new CPT (new TableFactor (vars, pC.toNativeArray ()), vars[2]));
+    mdl.addFactor (new CPT (new TableFactor (vars, pC.toArray ()), vars[2]));
 
     return mdl;
   }

--- a/src/cc/mallet/grmm/test/TestNormalFactor.java
+++ b/src/cc/mallet/grmm/test/TestNormalFactor.java
@@ -11,7 +11,7 @@ import cc.mallet.grmm.types.*;
 import cc.mallet.types.MatrixOps;
 import cc.mallet.util.Randoms;
 import junit.framework.*;
-import gnu.trove.TDoubleArrayList;
+import gnu.trove.list.array.TDoubleArrayList;
 import no.uib.cipr.matrix.Vector;
 import no.uib.cipr.matrix.DenseVector;
 import no.uib.cipr.matrix.Matrix;
@@ -54,7 +54,7 @@ public class TestNormalFactor extends TestCase {
 
   void checkMeanStd (TDoubleArrayList ell, double mu, double sigma)
   {
-    double[] vals = ell.toNativeArray ();
+    double[] vals = ell.toArray ();
     double mean1 = MatrixOps.mean (vals);
     double std1 = MatrixOps.stddev (vals);
     assertEquals (mu, mean1, 0.025);

--- a/src/cc/mallet/grmm/test/TestUniNormalFactor.java
+++ b/src/cc/mallet/grmm/test/TestUniNormalFactor.java
@@ -11,7 +11,7 @@ import cc.mallet.types.MatrixOps;
 import cc.mallet.util.Randoms;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import gnu.trove.TDoubleArrayList;
+import gnu.trove.list.array.TDoubleArrayList;
 
 /**
  * $Id: TestUniNormalFactor.java,v 1.1 2007/10/22 21:37:41 mccallum Exp $
@@ -58,7 +58,7 @@ public class TestUniNormalFactor extends TestCase {
       lst.add (assn.getDouble (var));
     }
 
-    double[] vals = lst.toNativeArray ();
+    double[] vals = lst.toArray ();
     double mean = MatrixOps.mean (vals);
     double std = MatrixOps.stddev (vals);
     assertEquals (-1.0, mean, 0.025);

--- a/src/cc/mallet/grmm/test/TestUniformFactor.java
+++ b/src/cc/mallet/grmm/test/TestUniformFactor.java
@@ -7,18 +7,17 @@
 
 package cc.mallet.grmm.test;
 
-import junit.framework.*;
-
-import gnu.trove.TDoubleArrayList;
-
-import java.io.BufferedReader;
-import java.io.StringReader;
-import java.io.IOException;
-
 import cc.mallet.grmm.types.*;
 import cc.mallet.grmm.util.ModelReader;
 import cc.mallet.types.MatrixOps;
 import cc.mallet.util.Randoms;
+import gnu.trove.list.array.TDoubleArrayList;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
 
 /**
  * $Id: TestUniformFactor.java,v 1.1 2007/10/22 21:37:41 mccallum Exp $
@@ -43,13 +42,13 @@ public class TestUniformFactor extends TestCase {
     Variable var = new Variable (Variable.CONTINUOUS);
     Randoms r = new Randoms (2343);
     Factor f = new UniformFactor (var, -1.0, 1.5);
-    TDoubleArrayList lst = new TDoubleArrayList ();
+    TDoubleArrayList lst = new TDoubleArrayList();
     for (int i = 0; i < 10000; i++) {
       Assignment assn = f.sample (r);
       lst.add (assn.getDouble (var));
     }
 
-    double[] vals = lst.toNativeArray ();
+    double[] vals = lst.toArray();
     double mean = MatrixOps.mean (vals);
     assertEquals (0.25, mean, 0.01);
   }

--- a/src/cc/mallet/grmm/types/AbstractTableFactor.java
+++ b/src/cc/mallet/grmm/types/AbstractTableFactor.java
@@ -7,7 +7,7 @@
 
 package cc.mallet.grmm.types;
 
-import gnu.trove.TIntObjectHashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/src/cc/mallet/grmm/types/Assignment.java
+++ b/src/cc/mallet/grmm/types/Assignment.java
@@ -7,7 +7,7 @@
 
 package cc.mallet.grmm.types;
 
-import gnu.trove.TObjectIntHashMap;
+import gnu.trove.map.hash.TObjectIntHashMap;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -176,7 +176,7 @@ public class Assignment extends AbstractFactor implements Serializable {
   public Assignment getRow (int ridx)
   {
     Assignment assn = new Assignment ();
-    assn.var2idx = (TObjectIntHashMap) this.var2idx.clone ();
+    assn.var2idx = new TObjectIntHashMap(this.var2idx);
     assn.vars = new UnmodifiableVarSet (vars);
     assn.addRow ((Object[]) values.get (ridx));
     return assn;
@@ -434,7 +434,7 @@ public class Assignment extends AbstractFactor implements Serializable {
   {
     Assignment ret = new Assignment ();
     ret.vars = new HashVarSet (vars);
-    ret.var2idx = (TObjectIntHashMap) var2idx.clone ();
+    ret.var2idx = new TObjectIntHashMap(var2idx);
     ret.values = new ArrayList (values.size ());
     for (int ri = 0; ri < values.size(); ri++) {
       Object[] vals = (Object[]) values.get (ri);

--- a/src/cc/mallet/grmm/types/BidirectionalIntObjectMap.java
+++ b/src/cc/mallet/grmm/types/BidirectionalIntObjectMap.java
@@ -6,10 +6,11 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.types;
 
+import gnu.trove.map.hash.TObjectIntHashMap;
+
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Iterator;
-
 /**
  * A mapping between integers and objects where the mapping in each
  * direction is efficient.  Integers are assigned consecutively, starting
@@ -23,13 +24,13 @@ import java.util.Iterator;
  */
 public class BidirectionalIntObjectMap implements Serializable {
 
-  gnu.trove.TObjectIntHashMap map;
+  TObjectIntHashMap map;
   ArrayList entries;
   boolean growthStopped = false;
 
   public BidirectionalIntObjectMap (int capacity)
   {
-    this.map = new gnu.trove.TObjectIntHashMap (capacity);
+    this.map = new TObjectIntHashMap (capacity);
     this.entries = new ArrayList (capacity);
   }
 
@@ -40,7 +41,7 @@ public class BidirectionalIntObjectMap implements Serializable {
 
   public BidirectionalIntObjectMap (BidirectionalIntObjectMap other)
   {
-    map = (gnu.trove.TObjectIntHashMap) other.map.clone ();
+    map = new TObjectIntHashMap(other.map);
     entries = (ArrayList) other.entries.clone ();
     growthStopped = other.growthStopped;
   }
@@ -200,7 +201,7 @@ public class BidirectionalIntObjectMap implements Serializable {
     in.readInt ();  // int version
     int size = in.readInt ();
     entries = new ArrayList (size);
-    map = new gnu.trove.TObjectIntHashMap (size);
+    map = new TObjectIntHashMap(size);
     for (int i = 0; i < size; i++) {
       Object o = in.readObject ();
       map.put (o, i);

--- a/src/cc/mallet/grmm/types/DirectedModel.java
+++ b/src/cc/mallet/grmm/types/DirectedModel.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import org._3pq.jgrapht.DirectedGraph;
 import org._3pq.jgrapht.graph.DefaultDirectedGraph;
 import org._3pq.jgrapht.alg.ConnectivityInspector;
-import gnu.trove.THashMap;
+import gnu.trove.map.hash.THashMap;
 
 
 /**

--- a/src/cc/mallet/grmm/types/FactorGraph.java
+++ b/src/cc/mallet/grmm/types/FactorGraph.java
@@ -7,10 +7,10 @@
 
 package cc.mallet.grmm.types;
 
-import gnu.trove.THashMap;
-import gnu.trove.THashSet;
-import gnu.trove.TObjectObjectProcedure;
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.set.hash.THashSet;
+import gnu.trove.procedure.TObjectObjectProcedure;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 import java.io.*;
 import java.util.*;

--- a/src/cc/mallet/grmm/types/Factors.java
+++ b/src/cc/mallet/grmm/types/Factors.java
@@ -14,8 +14,8 @@ import cc.mallet.grmm.util.Flops;
 import cc.mallet.types.*;
 import cc.mallet.util.*;
 
-import gnu.trove.TIntArrayList;
-import gnu.trove.TDoubleArrayList;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.list.array.TDoubleArrayList;
 
 /**
  * A static utility class containing utility methods for dealing with factors,
@@ -119,7 +119,7 @@ public class Factors {
     }
 
     int[] szs = computeSizes (ptl);
-    SparseMatrixn m = new SparseMatrixn (szs, idxList.toNativeArray (), valList.toNativeArray ());
+    SparseMatrixn m = new SparseMatrixn (szs, idxList.toArray (), valList.toArray ());
 
     TableFactor result = new TableFactor (computeVars (ptl));
     result.setValues (m);

--- a/src/cc/mallet/grmm/types/HashVarSet.java
+++ b/src/cc/mallet/grmm/types/HashVarSet.java
@@ -7,15 +7,14 @@
 
 package cc.mallet.grmm.types;
 
-import gnu.trove.THashSet;
+import cc.mallet.grmm.inference.Utils;
+import gnu.trove.set.hash.THashSet;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.*;
-
-import cc.mallet.grmm.inference.Utils;
 
 
 
@@ -183,7 +182,7 @@ public class HashVarSet implements VarSet, Serializable {
 
 	public Object clone()
   {
-		return verts.clone();
+       return new THashSet(verts);
 	}
 
 	public boolean add(Object object)

--- a/src/cc/mallet/grmm/types/ListVarSet.java
+++ b/src/cc/mallet/grmm/types/ListVarSet.java
@@ -6,8 +6,8 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.types;
 
-import gnu.trove.THashSet;
-import gnu.trove.TIntArrayList;
+import gnu.trove.set.hash.THashSet;
+import gnu.trove.list.array.TIntArrayList;
 
 import java.util.AbstractSet;
 import java.util.BitSet;
@@ -200,7 +200,7 @@ public class ListVarSet extends AbstractSet implements VarSet, Serializable {
     out.defaultWriteObject ();
     out.writeInt (CURRENT_SERIAL_VERSION);
     out.writeObject (universe);
-    out.writeObject (included.toNativeArray ());
+    out.writeObject (included.toArray ());
   }
 
 

--- a/src/cc/mallet/grmm/types/Tree.java
+++ b/src/cc/mallet/grmm/types/Tree.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 import cc.mallet.types.Alphabet;
 
-import gnu.trove.TObjectIntHashMap;
+import gnu.trove.map.hash.TObjectIntHashMap;
 
 
 /**

--- a/src/cc/mallet/grmm/types/UndirectedModel.java
+++ b/src/cc/mallet/grmm/types/UndirectedModel.java
@@ -6,13 +6,13 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.types;
 
-import java.util.*;
-
-import gnu.trove.THashSet;
+import cc.mallet.grmm.util.Graphs;
+import gnu.trove.set.hash.THashSet;
 import org._3pq.jgrapht.UndirectedGraph;
 import org._3pq.jgrapht.alg.ConnectivityInspector;
 
-import cc.mallet.grmm.util.Graphs;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Class for pairwise undirected graphical models, also known as

--- a/src/cc/mallet/grmm/types/Universe.java
+++ b/src/cc/mallet/grmm/types/Universe.java
@@ -6,16 +6,15 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.types;
 
-import gnu.trove.TIntArrayList;
-import gnu.trove.TIntObjectHashMap;
-import gnu.trove.THashMap;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.util.List;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A global mapping between variables and indices.

--- a/src/cc/mallet/grmm/util/CSIntInt2ObjectMultiMap.java
+++ b/src/cc/mallet/grmm/util/CSIntInt2ObjectMultiMap.java
@@ -6,9 +6,9 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.util;
 
-import gnu.trove.THashMap;
-import gnu.trove.TIntObjectHashMap;
-import gnu.trove.TObjectProcedure;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
+import gnu.trove.procedure.TObjectProcedure;
 
 import java.util.Iterator;
 import java.util.List;

--- a/src/cc/mallet/grmm/util/LabelsAssignment.java
+++ b/src/cc/mallet/grmm/util/LabelsAssignment.java
@@ -20,8 +20,8 @@ import cc.mallet.types.LabelsSequence;
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.AlphabetCarrying;
 
-import gnu.trove.THashMap;
-import gnu.trove.TIntArrayList;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.list.array.TIntArrayList;
 
 /**
  * A special kind of assignment for Variables that
@@ -69,7 +69,7 @@ public class LabelsAssignment extends Assignment implements AlphabetCarrying {
         vals.add (lbl.getIndex ());
       }
     }
-    return vals.toNativeArray ();
+    return vals.toArray ();
   }
 
   private void setupLabel2Var ()

--- a/src/cc/mallet/grmm/util/MIntInt2ObjectMap.java
+++ b/src/cc/mallet/grmm/util/MIntInt2ObjectMap.java
@@ -6,9 +6,9 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.util;
 
-import gnu.trove.TIntObjectHashMap;
-import gnu.trove.TObjectProcedure;
-import gnu.trove.TIntObjectIterator;
+import gnu.trove.map.hash.TIntObjectHashMap;
+import gnu.trove.procedure.TObjectProcedure;
+import gnu.trove.iterator.TIntObjectIterator;
 
 import java.io.Serializable;
 import java.io.ObjectOutputStream;
@@ -61,9 +61,9 @@ public class MIntInt2ObjectMap implements Serializable {
   {
     final TIntObjectHashMap inner = (TIntObjectHashMap) backing.get (key1);
     if (inner == null) {
-      return new TIntObjectIterator (new TIntObjectHashMap ());
+      return  (new TIntObjectHashMap ()).iterator();
     } else {
-      return new TIntObjectIterator (inner);
+      return inner.iterator();
     }
   }
 

--- a/src/cc/mallet/grmm/util/ModelReader.java
+++ b/src/cc/mallet/grmm/util/ModelReader.java
@@ -19,7 +19,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import cc.mallet.grmm.types.*;
 
-import gnu.trove.THashMap;
+import gnu.trove.map.hash.THashMap;
 import bsh.Interpreter;
 import bsh.EvalError;
 

--- a/src/cc/mallet/grmm/util/ModelWriter.java
+++ b/src/cc/mallet/grmm/util/ModelWriter.java
@@ -7,20 +7,12 @@
 package cc.mallet.grmm.util;
 
 
-import java.io.*;
-import java.util.List;
-import java.util.Iterator;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.regex.Pattern;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import cc.mallet.grmm.types.Factor;
+import cc.mallet.grmm.types.FactorGraph;
+import cc.mallet.grmm.types.Variable;
 
-import cc.mallet.grmm.types.*;
-
-import gnu.trove.THashMap;
-import bsh.Interpreter;
-import bsh.EvalError;
+import java.io.IOException;
+import java.io.Writer;
 
 /**
  * $Id: ModelReader.java,v 1.1 2007/10/22 21:37:58 mccallum Exp $

--- a/src/cc/mallet/grmm/util/Models.java
+++ b/src/cc/mallet/grmm/util/Models.java
@@ -14,7 +14,7 @@ import cc.mallet.grmm.inference.JunctionTree;
 import cc.mallet.grmm.inference.JunctionTreeInferencer;
 import cc.mallet.grmm.types.*;
 
-import gnu.trove.THashSet;
+import gnu.trove.set.hash.THashSet;
 
 /**
  * Static utilities that do useful things with factor graphs.

--- a/src/cc/mallet/grmm/util/THashMultiMap.java
+++ b/src/cc/mallet/grmm/util/THashMultiMap.java
@@ -6,9 +6,13 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.grmm.util;
 
-import gnu.trove.THashMap;
 
-import java.util.*;
+import gnu.trove.map.hash.THashMap;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Version of THashMap where every key is mapped to a list of objects.

--- a/src/cc/mallet/pipe/FeatureDocFreqPipe.java
+++ b/src/cc/mallet/pipe/FeatureDocFreqPipe.java
@@ -1,8 +1,10 @@
 package cc.mallet.pipe;
 
-import cc.mallet.types.*;
-import gnu.trove.*;
-import java.io.*;
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.FeatureCounter;
+import cc.mallet.types.FeatureSequence;
+import cc.mallet.types.Instance;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 /** 
  *  Pruning low-count features can be a good way to save memory and computation.

--- a/src/cc/mallet/pipe/tsf/LexiconMembership.java
+++ b/src/cc/mallet/pipe/tsf/LexiconMembership.java
@@ -17,21 +17,24 @@
 
 package cc.mallet.pipe.tsf;
 
-import java.io.*;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.types.Instance;
+import cc.mallet.types.Token;
+import cc.mallet.types.TokenSequence;
+import gnu.trove.set.hash.THashSet;
 
-import cc.mallet.pipe.*;
-import cc.mallet.types.*;
+import java.io.*;
 
 public class LexiconMembership extends Pipe implements Serializable
 {
 	String name;
-	gnu.trove.THashSet lexicon;
+	THashSet lexicon;
 	boolean ignoreCase;
 	
 	public LexiconMembership (String name, Reader lexiconReader, boolean ignoreCase)
 	{
 		this.name = name;
-		this.lexicon = new gnu.trove.THashSet ();
+		this.lexicon = new THashSet ();
 		this.ignoreCase = ignoreCase;
 		LineNumberReader reader = new LineNumberReader (lexiconReader);
 		String line;
@@ -104,7 +107,7 @@ public class LexiconMembership extends Pipe implements Serializable
 	private void readObject (ObjectInputStream in) throws IOException, ClassNotFoundException {
 		int version = in.readInt ();
 		this.name = (String) in.readObject();
-		this.lexicon = (gnu.trove.THashSet) in.readObject();
+		this.lexicon = (THashSet) in.readObject();
 		this.ignoreCase = in.readBoolean();
 	}
 

--- a/src/cc/mallet/share/upenn/ner/FeatureWindow.java
+++ b/src/cc/mallet/share/upenn/ner/FeatureWindow.java
@@ -1,12 +1,12 @@
 package cc.mallet.share.upenn.ner;
 
 
-import java.util.*;
-
-import cc.mallet.pipe.*;
-import cc.mallet.types.*;
-import cc.mallet.util.*;
-import gnu.trove.*;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.types.Instance;
+import cc.mallet.types.Token;
+import cc.mallet.types.TokenSequence;
+import cc.mallet.util.PropertyList;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 /**
  * Adds all features of tokens in the window to the center token.

--- a/src/cc/mallet/share/upenn/ner/ListMember.java
+++ b/src/cc/mallet/share/upenn/ner/ListMember.java
@@ -1,13 +1,17 @@
 package cc.mallet.share.upenn.ner;
 
 
-import java.io.*;
-import java.util.*;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.types.Instance;
+import cc.mallet.types.TokenSequence;
+import gnu.trove.set.hash.THashSet;
 
-import cc.mallet.pipe.*;
-import cc.mallet.types.*;
-
-import gnu.trove.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Set;
+import java.util.StringTokenizer;
 
 /**
  * Checks membership in a lexicon in a text file.  Multi-token items are supported,

--- a/src/cc/mallet/topics/DMROptimizable.java
+++ b/src/cc/mallet/topics/DMROptimizable.java
@@ -26,7 +26,7 @@ import java.util.*;
 import java.text.NumberFormat;
 import java.text.DecimalFormat;
 
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 public class DMROptimizable implements Optimizable.ByGradientValue {
 

--- a/src/cc/mallet/topics/DMRTopicModel.java
+++ b/src/cc/mallet/topics/DMRTopicModel.java
@@ -8,7 +8,6 @@ import cc.mallet.classify.MaxEnt;
 import cc.mallet.pipe.Pipe;
 import cc.mallet.pipe.Noop;
 
-import gnu.trove.TIntIntHashMap;
 
 import java.io.IOException;
 import java.io.PrintStream;

--- a/src/cc/mallet/topics/HierarchicalLDA.java
+++ b/src/cc/mallet/topics/HierarchicalLDA.java
@@ -6,8 +6,8 @@ import java.io.*;
 
 import cc.mallet.types.*;
 import cc.mallet.util.Randoms;
-
-import gnu.trove.*;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 public class HierarchicalLDA {
 

--- a/src/cc/mallet/topics/LDAHyper.java
+++ b/src/cc/mallet/topics/LDAHyper.java
@@ -7,7 +7,8 @@
 
 package cc.mallet.topics;
 
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.map.hash.TObjectIntHashMap;
 
 import java.util.Arrays;
 import java.util.List;
@@ -91,7 +92,7 @@ public class LDAHyper implements Serializable {
 	// garbage collection overhead.
 	protected int[] oneDocTopicCounts; // indexed by <document index, topic index>
 
-	protected gnu.trove.TIntIntHashMap[] typeTopicCounts; // indexed by <feature index, topic index>
+	protected TIntIntHashMap[] typeTopicCounts; // indexed by <feature index, topic index>
 	protected int[] tokensPerTopic; // indexed by <topic index>
 
 	// for dirichlet estimation
@@ -457,7 +458,7 @@ public class LDAHyper implements Serializable {
 
 			// Build a distribution over topics for this token
 			topicIndices = currentTypeTopicCounts.keys();
-			topicCounts = currentTypeTopicCounts.getValues();
+			topicCounts = currentTypeTopicCounts.values();
 			topicDistribution = new double[topicIndices.length]; 
 			// TODO Yipes, memory allocation in the inner loop!  But note that .keys and .getValues is doing this too.
 			topicDistributionSum = 0;
@@ -571,7 +572,7 @@ public class LDAHyper implements Serializable {
 			topicTermMass = 0.0;
 
 			topicTermIndices = currentTypeTopicCounts.keys();
-			topicTermValues = currentTypeTopicCounts.getValues();
+			topicTermValues = currentTypeTopicCounts.values();
 
 			for (i=0; i < topicTermIndices.length; i++) {
 				int topic = topicTermIndices[i];
@@ -618,7 +619,7 @@ public class LDAHyper implements Serializable {
 					sample /= beta;
 
 					topicTermIndices = localTopicCounts.keys();
-					topicTermValues = localTopicCounts.getValues();
+					topicTermValues = localTopicCounts.values();
 
 					for (i=0; i < topicTermIndices.length; i++) {
 						newTopic = topicTermIndices[i];
@@ -799,12 +800,12 @@ public class LDAHyper implements Serializable {
 	
 	public void topicXMLReportPhrases (PrintStream out, int numWords) {
 		int numTopics = this.getNumTopics();
-		gnu.trove.TObjectIntHashMap<String>[] phrases = new gnu.trove.TObjectIntHashMap[numTopics];
+		TObjectIntHashMap<String>[] phrases = new TObjectIntHashMap[numTopics];
 		Alphabet alphabet = this.getAlphabet();
 		
 		// Get counts of phrases
 		for (int ti = 0; ti < numTopics; ti++)
-			phrases[ti] = new gnu.trove.TObjectIntHashMap<String>();
+			phrases[ti] = new TObjectIntHashMap<String>();
 		for (int di = 0; di < this.getData().size(); di++) {
 			LDAHyper.Topication t = this.getData().get(di);
 			Instance instance = t.instance;
@@ -872,7 +873,7 @@ public class LDAHyper implements Serializable {
 
 			// Print phrases
 			Object[] keys = phrases[ti].keys();
-			int[] values = phrases[ti].getValues();
+			int[] values = phrases[ti].values();
 			double counts[] = new double[keys.length];
 			for (int i = 0; i < counts.length; i++)	counts[i] = values[i];
 			double countssum = MatrixOps.sum (counts);	

--- a/src/cc/mallet/topics/LDAStream.java
+++ b/src/cc/mallet/topics/LDAStream.java
@@ -23,7 +23,7 @@ import cc.mallet.types.InstanceList;
 import cc.mallet.types.LabelAlphabet;
 import cc.mallet.types.LabelSequence;
 import cc.mallet.util.Randoms;
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 /**
  * @author Limin Yao, David Mimno

--- a/src/cc/mallet/topics/MultinomialHMM.java
+++ b/src/cc/mallet/topics/MultinomialHMM.java
@@ -7,18 +7,15 @@
 
 package cc.mallet.topics;
 
-import cc.mallet.types.*;
+import cc.mallet.types.IDSorter;
 import cc.mallet.util.Randoms;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.zip.*;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.io.*;
 import java.text.NumberFormat;
-
-import gnu.trove.*;
+import java.util.Arrays;
+import java.util.zip.GZIPInputStream;
 
 /**
  * Latent Dirichlet Allocation.

--- a/src/cc/mallet/topics/NPTopicModel.java
+++ b/src/cc/mallet/topics/NPTopicModel.java
@@ -17,8 +17,7 @@ import java.text.NumberFormat;
 import cc.mallet.topics.*;
 import cc.mallet.types.*;
 import cc.mallet.util.*;
-
-import gnu.trove.*;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 /**
  * A non-parametric topic model that uses the "minimal path" assumption

--- a/src/cc/mallet/topics/ParallelTopicModel.java
+++ b/src/cc/mallet/topics/ParallelTopicModel.java
@@ -7,25 +7,19 @@
 
 package cc.mallet.topics;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.TreeSet;
-import java.util.Iterator;
-import java.util.Formatter;
-import java.util.Locale;
-
-import java.util.concurrent.*;
-import java.util.logging.*;
-import java.util.zip.*;
+import cc.mallet.types.*;
+import cc.mallet.util.MalletLogger;
+import cc.mallet.util.Randoms;
+import gnu.trove.map.hash.TObjectIntHashMap;
 
 import java.io.*;
 import java.text.NumberFormat;
-
-import cc.mallet.types.*;
-import cc.mallet.topics.TopicAssignment;
-import cc.mallet.util.Randoms;
-import cc.mallet.util.MalletLogger;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * Simple parallel threaded implementation of LDA,
@@ -1228,12 +1222,12 @@ public class ParallelTopicModel implements Serializable {
 
 	public void topicPhraseXMLReport(PrintWriter out, int numWords) {
 		int numTopics = this.getNumTopics();
-		gnu.trove.TObjectIntHashMap<String>[] phrases = new gnu.trove.TObjectIntHashMap[numTopics];
+		TObjectIntHashMap<String>[] phrases = new TObjectIntHashMap[numTopics];
 		Alphabet alphabet = this.getAlphabet();
 		
 		// Get counts of phrases
 		for (int ti = 0; ti < numTopics; ti++)
-			phrases[ti] = new gnu.trove.TObjectIntHashMap<String>();
+			phrases[ti] = new TObjectIntHashMap<String>();
 		for (int di = 0; di < this.getData().size(); di++) {
 			TopicAssignment t = this.getData().get(di);
 			Instance instance = t.instance;
@@ -1316,7 +1310,7 @@ public class ParallelTopicModel implements Serializable {
 
 			// Print phrases
 			Object[] keys = phrases[ti].keys();
-			int[] values = phrases[ti].getValues();
+			int[] values = phrases[ti].values();
 			double counts[] = new double[keys.length];
 			for (int i = 0; i < counts.length; i++)	counts[i] = values[i];
 			double countssum = MatrixOps.sum (counts);	
@@ -1729,7 +1723,7 @@ public class ParallelTopicModel implements Serializable {
 
 	/**
 	 *  @param out		  A print writer
-	 *  @param count      Print this number of top documents
+	 *  @param max      Print this number of top documents
 	 */
 	public void printTopicDocuments (PrintWriter out, int max)	{
 		out.println("#topic doc name proportion ...");

--- a/src/cc/mallet/topics/RTopicModel.java
+++ b/src/cc/mallet/topics/RTopicModel.java
@@ -1,7 +1,7 @@
 package cc.mallet.topics;
 
 import cc.mallet.types.*;
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 import java.io.*;
 
 /** A wrapper for a topic model to be used from the R statistical package through rJava.

--- a/src/cc/mallet/topics/TopicModelDiagnostics.java
+++ b/src/cc/mallet/topics/TopicModelDiagnostics.java
@@ -1,13 +1,14 @@
 package cc.mallet.topics;
 
-import java.io.*;
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.FeatureSequence;
+import cc.mallet.types.IDSorter;
+import cc.mallet.types.InstanceList;
+import gnu.trove.set.hash.TIntHashSet;
+
+import java.io.File;
+import java.io.PrintWriter;
 import java.util.*;
-import java.text.*;
-
-import cc.mallet.types.*;
-import cc.mallet.util.*;
-
-import gnu.trove.*;
 
 public class TopicModelDiagnostics {
 

--- a/src/cc/mallet/topics/WeightedTopicModel.java
+++ b/src/cc/mallet/topics/WeightedTopicModel.java
@@ -1,17 +1,18 @@
 package cc.mallet.topics;
 
-import java.util.*;
-import java.util.logging.*;
-import java.util.zip.*;
-import java.util.regex.*;
+import cc.mallet.types.*;
+import cc.mallet.util.CommandOption;
+import cc.mallet.util.MalletLogger;
+import cc.mallet.util.Randoms;
+import gnu.trove.map.hash.TIntDoubleHashMap;
 
 import java.io.*;
 import java.text.NumberFormat;
-
-import cc.mallet.types.*;
-import cc.mallet.util.*;
-
-import gnu.trove.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPOutputStream;
 
 public class WeightedTopicModel implements Serializable {
 

--- a/src/cc/mallet/types/Alphabet.java
+++ b/src/cc/mallet/types/Alphabet.java
@@ -13,7 +13,7 @@
  */
 
 package cc.mallet.types;
-
+import gnu.trove.map.hash.TObjectIntHashMap;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -50,7 +50,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class Alphabet implements Serializable
 {
-	gnu.trove.TObjectIntHashMap map;
+	TObjectIntHashMap map;
 	ArrayList entries;
 	volatile boolean growthStopped = false;
 	Class entryClass = null;
@@ -60,7 +60,7 @@ public class Alphabet implements Serializable
 
 	public Alphabet (int capacity, Class entryClass)
 	{
-		this.map = new gnu.trove.TObjectIntHashMap (capacity);
+		this.map = new TObjectIntHashMap (capacity);
 		this.entries = new ArrayList (capacity);
 		this.entryClass = entryClass;
 		// someone could try to deserialize us into this image (e.g., by RMI).  Handle this.
@@ -93,7 +93,7 @@ public class Alphabet implements Serializable
         lock.readLock().lock();
         try {
             Alphabet ret = new Alphabet();
-            ret.map = (gnu.trove.TObjectIntHashMap) map.clone();
+            ret.map = new TObjectIntHashMap(map);
             ret.entries = (ArrayList) entries.clone();
             ret.growthStopped = growthStopped;
             ret.entryClass = entryClass;
@@ -352,7 +352,7 @@ public class Alphabet implements Serializable
             int version = in.readInt();
             int size = in.readInt();
             entries = new ArrayList(size);
-            map = new gnu.trove.TObjectIntHashMap(size);
+            map = new TObjectIntHashMap(size);
             for (int i = 0; i < size; i++) {
                 Object o = in.readObject();
                 map.put(o, i);

--- a/src/cc/mallet/types/Dirichlet.java
+++ b/src/cc/mallet/types/Dirichlet.java
@@ -7,9 +7,9 @@
 
 package cc.mallet.types;
 
-import gnu.trove.TIntHashSet;
-import gnu.trove.TIntIntHashMap;
-import gnu.trove.TIntIterator;
+import gnu.trove.set.hash.TIntHashSet;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.iterator.TIntIterator;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;

--- a/src/cc/mallet/types/FeatureCounter.java
+++ b/src/cc/mallet/types/FeatureCounter.java
@@ -1,14 +1,16 @@
 package cc.mallet.types;
+import gnu.trove.map.hash.TIntIntHashMap;
+
 
 /** Efficient, compact, incremental counting of features in an alphabet. */
 public class FeatureCounter 
 {
 	Alphabet alphabet;
-	gnu.trove.TIntIntHashMap featureCounts;
+	TIntIntHashMap featureCounts;
 	
 	public FeatureCounter (Alphabet alphabet) {
 		this.alphabet = alphabet;
-		featureCounts = new gnu.trove.TIntIntHashMap();
+		featureCounts = new TIntIntHashMap();
 	}
 	
 	public int increment (Object entry) {

--- a/src/cc/mallet/types/HashedSparseVector.java
+++ b/src/cc/mallet/types/HashedSparseVector.java
@@ -17,18 +17,15 @@
 
 package cc.mallet.types;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Arrays;
-import java.util.logging.*;
-import java.io.*;
-
-import cc.mallet.types.Alphabet;
-import cc.mallet.types.FeatureSequence;
-import cc.mallet.types.Vector;
 import cc.mallet.util.MalletLogger;
-import cc.mallet.util.PropertyList;
-import gnu.trove.TIntIntHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.logging.Logger;
+
 
 public class HashedSparseVector extends SparseVector implements Serializable 
 {

--- a/src/cc/mallet/types/StringEditFeatureVectorSequence.java
+++ b/src/cc/mallet/types/StringEditFeatureVectorSequence.java
@@ -17,7 +17,7 @@ package cc.mallet.types;
 import java.io.*;
 import java.util.regex.*;
 import java.util.HashMap;
-import gnu.trove.TObjectIntHashMap;
+import gnu.trove.map.hash.TObjectIntHashMap;
 import java.util.Set;
 import java.util.Iterator;
 

--- a/src/cc/mallet/types/tests/TestSparseMatrixn.java
+++ b/src/cc/mallet/types/tests/TestSparseMatrixn.java
@@ -6,19 +6,15 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.types.tests;
 
+import cc.mallet.types.SparseMatrixn;
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TIntArrayList;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
-import java.util.Arrays;
 import java.io.IOException;
-
-import cc.mallet.types.MatrixOps;
-import cc.mallet.types.Matrixn;
-import cc.mallet.types.SparseMatrixn;
-
-import gnu.trove.TIntArrayList;
-import gnu.trove.TDoubleArrayList;
+import java.util.Arrays;
 
 /**
  * Created: Aug 30, 2004
@@ -80,7 +76,7 @@ public class TestSparseMatrixn extends TestCase {
   private SparseMatrixn make3dMatrix ()
   {
     int[] sizes = new int[]{2, 3, 4};
-    TIntArrayList idxs = new TIntArrayList ();
+    TIntArrayList idxs = new TIntArrayList();
     TDoubleArrayList vals = new TDoubleArrayList ();
 
     for (int i = 0; i < 24; i++) {
@@ -90,7 +86,7 @@ public class TestSparseMatrixn extends TestCase {
       }
     }
 
-    SparseMatrixn a = new SparseMatrixn (sizes, idxs.toNativeArray (), vals.toNativeArray ());
+    SparseMatrixn a = new SparseMatrixn (sizes, idxs.toArray (), vals.toArray ());
     return a;
   }
 

--- a/src/cc/mallet/util/ArrayUtils.java
+++ b/src/cc/mallet/util/ArrayUtils.java
@@ -7,8 +7,8 @@
 
 package cc.mallet.util;
 
-import gnu.trove.TDoubleProcedure;
-import gnu.trove.TObjectProcedure;
+import gnu.trove.procedure.TDoubleProcedure;
+import gnu.trove.procedure.TObjectProcedure;
 
 import java.lang.reflect.Array;
 

--- a/src/cc/mallet/util/CollectionUtils.java
+++ b/src/cc/mallet/util/CollectionUtils.java
@@ -7,9 +7,9 @@
 
 package cc.mallet.util;
 
-import gnu.trove.THashSet;
-import gnu.trove.TObjectDoubleHashMap;
-import gnu.trove.TObjectDoubleProcedure;
+import gnu.trove.set.hash.THashSet;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
+import gnu.trove.procedure.TObjectDoubleProcedure;
 
 import java.util.*;
 

--- a/src/cc/mallet/util/FeatureCooccurrenceCounter.java
+++ b/src/cc/mallet/util/FeatureCooccurrenceCounter.java
@@ -1,12 +1,14 @@
 package cc.mallet.util;
 
 import cc.mallet.types.*;
-import gnu.trove.*;
+import gnu.trove.map.hash.TIntIntHashMap;
 
-import java.util.Arrays;
-import java.util.logging.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.text.NumberFormat;
-import java.io.*;
+import java.util.Arrays;
+import java.util.logging.Logger;
 
 public class FeatureCooccurrenceCounter {
 

--- a/src/cc/mallet/util/FeatureCountTool.java
+++ b/src/cc/mallet/util/FeatureCountTool.java
@@ -1,14 +1,13 @@
 package cc.mallet.util;
 
 import cc.mallet.types.*;
-import gnu.trove.*;
+import gnu.trove.map.hash.TIntIntHashMap;
 
+import java.io.File;
+import java.text.NumberFormat;
 import java.util.Formatter;
 import java.util.Locale;
-import java.util.logging.*;
-import java.io.*;
-
-import java.text.NumberFormat;
+import java.util.logging.Logger;
 
 public class FeatureCountTool {
 

--- a/src/cc/mallet/util/VectorStats.java
+++ b/src/cc/mallet/util/VectorStats.java
@@ -14,11 +14,14 @@ package cc.mallet.util;
  *  @author Jerod Weinman <A HREF="mailto:weinman@cs.umass.edu">weinman@cs.umass.edu</A>
  */
 
+import cc.mallet.types.Instance;
+import cc.mallet.types.InstanceList;
+import cc.mallet.types.SparseVector;
+import gnu.trove.set.hash.TIntHashSet;
+
 import java.util.Arrays;
 import java.util.Iterator;
 
-import cc.mallet.types.*;
-import gnu.trove.TIntHashSet;
 
 public class VectorStats {
 
@@ -215,7 +218,6 @@ public class VectorStats {
 	 *          Mean of the given instances.
 	 * @param unbiased
 	 *          Normalizes variance by N-1 when true, and by N otherwise.
-	 * @see variance
 	 */
 	public static SparseVector stddev(InstanceList instances, SparseVector mean,
 			boolean unbiased) {
@@ -249,7 +251,6 @@ public class VectorStats {
 	 * 
 	 * @param unbiased
 	 *          Normalizes variance by N-1 when true, and by N otherwise.
-	 * @see variance
 	 */
 	public static SparseVector stddev(InstanceList instances, boolean unbiased) {
 		return stddev(instances, mean(instances), unbiased);


### PR DESCRIPTION
Note that Mallet tests were failing for me in Maven before I forked the code.  However, the changes are minimal and I believe that there are no regressions (and no more tests are failing than were failing before)

I have done a similar change back when Mallet was using Mercurial -- my mods there are on bitbucket, which I have been using for topic modeling for over a year with no obvious problems.

I understand from the discussions I have read that Trove 3 may not be a desirable change for the Mallet team and that's fine if cannot be merged due to licenses, etc.  For me, I was integrating into a project using 3 and downgrading to 2 was not an option.

