### PR TITLE
Typo Error

### DIFF
--- a/src/cc/mallet/grmm/examples/SimpleCrfExample.java
+++ b/src/cc/mallet/grmm/examples/SimpleCrfExample.java
@@ -45,7 +45,7 @@ public class SimpleCrfExample {
                                          true));
 
     InstanceList testing = new InstanceList (pipe);
-    training.addThruPipe (new LineGroupIterator (new FileReader (testFile),
+    testing.addThruPipe (new LineGroupIterator (new FileReader (testFile),
                                          Pattern.compile ("\\s*"),
                                          true));
 


### PR DESCRIPTION
Fix a typo when I used this example for CRF modelling .(line 47 and 48)