### PR TITLE
Close PrintWriter when calling print() from MaxEnt

### DIFF
--- a/src/cc/mallet/classify/MaxEnt.java
+++ b/src/cc/mallet/classify/MaxEnt.java
@@ -200,7 +200,9 @@ public class MaxEnt extends Classifier implements Serializable
 	}
 
 	public void print () {
-		print(System.out);
+		PrintWriter outWriter = new PrintWriter(System.out);
+		print(outWriter);
+		outWriter.close();
 	}
 
 	@Override


### PR DESCRIPTION
Fixed the bug where calling print() won't print out anything (unless it gets enough input...)
PrintWriter needs to be flushed or closed.