### PR TITLE
Remove some excess whitespace in Label type

### DIFF
--- a/src/cc/mallet/types/Label.java
+++ b/src/cc/mallet/types/Label.java
@@ -163,8 +163,7 @@ public class Label implements Labeling, Serializable, AlphabetCarrying
 
 	public LabelVector toLabelVector ()
 	{
-		return new LabelVector ((LabelAlphabet)dictionary,
-														new int[] {index}, new double[] {weightOfLabel});
+		return new LabelVector ((LabelAlphabet)dictionary, new int[] {index}, new double[] {weightOfLabel});
 	}
 
 	public boolean equals (Object l) {


### PR DESCRIPTION
Remove a line and a half of excess tabs in the middle of the toLabelVector() method of the Label class