### PR TITLE
Allow spaces in paths

### DIFF
--- a/bin/classifier2info
+++ b/bin/classifier2info
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.Classifier2Info "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.Classifier2Info "$@"
 

--- a/bin/csv2classify
+++ b/bin/csv2classify
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.Csv2Classify "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.Csv2Classify "$@"
 

--- a/bin/csv2vectors
+++ b/bin/csv2vectors
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.Csv2Vectors "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.Csv2Vectors "$@"
 

--- a/bin/mallet
+++ b/bin/mallet
@@ -59,4 +59,4 @@ case $CMD in
 	*) echo "Unrecognized command: $CMD"; help; exit 1;;
 esac
 
-$JAVA_COMMAND $CLASS $*
+$JAVA_COMMAND $CLASS "$@"

--- a/bin/mallet
+++ b/bin/mallet
@@ -9,8 +9,6 @@ cp=$malletdir/class:$malletdir/lib/mallet-deps.jar:$CLASSPATH
 
 MEMORY=1g
 
-JAVA_COMMAND="java -Xmx$MEMORY -ea -Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -classpath $cp"
-
 CMD=$1
 shift
 
@@ -59,4 +57,4 @@ case $CMD in
 	*) echo "Unrecognized command: $CMD"; help; exit 1;;
 esac
 
-$JAVA_COMMAND $CLASS "$@"
+java -Xmx$MEMORY -ea -Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -classpath "$cp" $CLASS "$@"

--- a/bin/svmlight2vectors
+++ b/bin/svmlight2vectors
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.SvmLight2Vectors "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.SvmLight2Vectors "$@"
 

--- a/bin/text2classify
+++ b/bin/text2classify
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.Text2Classify "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.Text2Classify "$@"
 

--- a/bin/text2vectors
+++ b/bin/text2vectors
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.Text2Vectors "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.Text2Vectors "$@"
 

--- a/bin/vectors2classify
+++ b/bin/vectors2classify
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.Vectors2Classify "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.Vectors2Classify "$@"
 

--- a/bin/vectors2info
+++ b/bin/vectors2info
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.Vectors2Info "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.Vectors2Info "$@"
 

--- a/bin/vectors2topics
+++ b/bin/vectors2topics
@@ -18,4 +18,4 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.topics.tui.Vectors2Topics "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.topics.tui.Vectors2Topics "$@"

--- a/bin/vectors2vectors
+++ b/bin/vectors2vectors
@@ -18,5 +18,5 @@ if test $1 != $arg ; then
   shift 
 fi
 
-java -Xmx$mem -server -classpath $cp cc.mallet.classify.tui.Vectors2Vectors "$@"
+java -Xmx$mem -server -classpath "$cp" cc.mallet.classify.tui.Vectors2Vectors "$@"
 


### PR DESCRIPTION
First commit enables spaces in paths passed to `bin/mallet`, fixing the following behavior:
```
$ mkdir temp\ dir
$ echo "1 1 1\n2 2 2" > temp\ dir/data.txt
$ bin/mallet import-file --output temp\ dir/data.mallet --input temp\ dir/data.txt
...
Exception in thread "main" java.lang.IllegalArgumentException: Unrecognized option 2: dir/data.mallet
...
```

Second commit enables spaces in `$CLASSPATH`, fixing the following behavior:
```
$ CLASSPATH=temp\ dir bin/csv2vectors --input temp\ dir/data.txt --output temp\ dir/data.out
Error: Could not find or load main class dir
```