### PR TITLE
Fix WordEmbeddings#write output format to Locale.US

### DIFF
--- a/src/cc/mallet/pipe/FeatureCountPipe.java
+++ b/src/cc/mallet/pipe/FeatureCountPipe.java
@@ -61,7 +61,7 @@ public class FeatureCountPipe extends Pipe {
 
 		for (int feature = 0; feature < currentAlphabet.size(); feature++) {
 			if (counter.get(feature) >= minimumCount) {
-				prunedAlphabet.lookupObject(currentAlphabet.lookupIndex(feature));
+				prunedAlphabet.lookupIndex(currentAlphabet.lookupObject(feature));
 			}
 		}
 

--- a/src/cc/mallet/topics/WordEmbeddingRunnable.java
+++ b/src/cc/mallet/topics/WordEmbeddingRunnable.java
@@ -54,8 +54,6 @@ public class WordEmbeddingRunnable implements Runnable {
 
 		double[] gradient = new double[numColumns];
 
-		int queryID = model.vocabulary.lookupIndex(model.queryWord);
-
 		int outputOffset = model.numColumns;
 
 		docID = threadID * (numDocuments / numThreads);

--- a/src/cc/mallet/topics/WordEmbeddings.java
+++ b/src/cc/mallet/topics/WordEmbeddings.java
@@ -224,7 +224,7 @@ public class WordEmbeddings {
 
 	public void write(PrintWriter out) {
 		for (int word = 0; word < numWords; word++) {
-			Formatter buffer = new Formatter();
+			Formatter buffer = new Formatter(Locale.US);
 			buffer.format("%s", vocabulary.lookupObject(word));
 			for (int col = 0; col < numColumns; col++) {
 				buffer.format(" %.6f", weights[word * stride + col]);

--- a/src/cc/mallet/topics/WordEmbeddings.java
+++ b/src/cc/mallet/topics/WordEmbeddings.java
@@ -55,7 +55,17 @@ public class WordEmbeddings {
 
 	int windowSize = 5;
 
-	String queryWord = "the";
+	public String getQueryWord()
+	{
+		return queryWord;
+	}
+
+	public void setQueryWord(String queryWord)
+	{
+		this.queryWord = queryWord;
+	}
+
+	private String queryWord = "the";
 
 	Randoms random = new Randoms();
 
@@ -170,7 +180,7 @@ public class WordEmbeddings {
 				}
 			}
 
-			if (queryWord != null) {
+			if (queryWord != null && vocabulary.contains(queryWord)) {
 				findClosest(copy(queryWord));
 			}
 		}

--- a/src/cc/mallet/topics/WordEmbeddings.java
+++ b/src/cc/mallet/topics/WordEmbeddings.java
@@ -65,7 +65,7 @@ public class WordEmbeddings {
 		this.queryWord = queryWord;
 	}
 
-	private String queryWord = "the";
+	String queryWord = "the";
 
 	Randoms random = new Randoms();
 


### PR DESCRIPTION
Fix the number output format of WordEmbeddings to Locale.US. Otherwise, the system default locale is used which may result in varying decimal separators.
