### PR TITLE
French stoplist

### DIFF
--- a/src/cc/mallet/pipe/TokenSequenceRemoveStopwords.java
+++ b/src/cc/mallet/pipe/TokenSequenceRemoveStopwords.java
@@ -748,7 +748,7 @@ public class TokenSequenceRemoveStopwords extends Pipe implements Serializable
 		//"approach"
 	};	
 		//stopwords for french, added by Limin Yao
-	static final String[] stopwordsFrench = {
+	public static final String[] stopwordsFrench = {
 		"fut",
 		"S",
 		"ces",


### PR DESCRIPTION
Make the built-in French stopword list `public`, which is otherwise unusable because client code can't access it.