### PR TITLE
Add source files to jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,10 @@
  
   <!-- Create a jar file -->
   <target name="jar" depends="compile">
-      <jar destfile="${dist}/mallet.jar" basedir="${class}"/>
+    <jar destfile="${dist}/mallet.jar" basedir="${class}">
+      <fileset dir="${class}/cc/mallet/" />
+      <fileset dir="${src}" includes="**/*.java"/>
+    </jar>
   </target>
 
   <target name="test" depends="compile">


### PR DESCRIPTION
This makes is easier for people importing the jar to drill down through
definitions in the Java IDE of their choice.

This will also present javadocs in your IDE when available.