### PR TITLE
Use toString instead of directly casting to string when outputting doc-topic

### DIFF
--- a/src/cc/mallet/topics/ParallelTopicModel.java
+++ b/src/cc/mallet/topics/ParallelTopicModel.java
@@ -1770,7 +1770,7 @@ public class ParallelTopicModel implements Serializable {
 				
 				int doc = sorter.getID();
 				double proportion = sorter.getWeight();
-				String name = (String) data.get(doc).instance.getName();
+				String name = data.get(doc).instance.getName().toString();
 				if (name == null) {
 					name = "no-name";
 				}


### PR DESCRIPTION
When telling mallet train-topics to output doc-topic, it gives this error:
Exception in thread "main" java.lang.ClassCastException: java.net.URI cannot be cast to java.lang.String
at cc.mallet.topics.ParallelTopicModel.printTopicDocuments(ParallelTopicModel.java:1748)
at cc.mallet.topics.tui.TopicTrainer.main(TopicTrainer.java:281)

The fix has been discussed here https://github.com/mimno/Mallet/issues/29
