### PR TITLE
Making SimpleTagger and PerClassAccuracyEvaluator capable of reporting precision, recall and F1

### DIFF
--- a/src/cc/mallet/fst/PerClassAccuracyEvaluator.java
+++ b/src/cc/mallet/fst/PerClassAccuracyEvaluator.java
@@ -15,6 +15,8 @@ import java.text.DecimalFormat;
 import cc.mallet.types.*;
 import cc.mallet.util.MalletLogger;
 
+import java.util.ArrayList;
+
 /**
  * Determines the precision, recall and F1 on a per-class basis.
  * 
@@ -64,18 +66,47 @@ public class PerClassAccuracyEvaluator extends TransducerEvaluator {
     }
 
     DecimalFormat f = new DecimalFormat ("0.####");
+    
+    double[] allp = new double [numLabels];
+    double[] allr = new double [numLabels];
     double[] allf = new double [numLabels];
+    
+    ArrayList<Double> usedp = new ArrayList<Double>();
+    ArrayList<Double> usedr = new ArrayList<Double>();
+    ArrayList<Double> usedf = new ArrayList<Double>();
+
     for (int i = 0; i < numLabels; i++) {
       Object label = dict.lookupObject(i);
       double precision = ((double) numCorrectTokens[i]) / numPredTokens[i];
       double recall = ((double) numCorrectTokens[i]) / numTrueTokens[i];
       double f1 = (2 * precision * recall) / (precision + recall);
-      if (!Double.isNaN (f1)) allf [i] = f1;
+      
+      if (!Double.isNaN (precision)) {
+      	allp [i] = precision;
+      	usedp.add(precision);
+      }
+      if (!Double.isNaN (recall)){
+      	allr [i] = recall;
+      	usedr.add(recall);
+      } 
+      if (!Double.isNaN (f1)){
+      	allf [i] = f1;
+      	usedf.add(f1);
+      } 
+
       logger.info(description +" label " + label + " P " + f.format (precision)
                   + " R " + f.format(recall) + " F1 "+ f.format (f1));
     }
 
-    logger.info ("Macro-average F1 "+f.format (MatrixOps.mean (allf)));
+    logger.info ("Macro-average (including non-used labels)" +  
+    	" P "+f.format (MatrixOps.mean (allp))  + 
+    	" R "+ f.format (MatrixOps.mean (allr)) +
+    	" F " + f.format (MatrixOps.mean (allf)));
+
+    logger.info ("Macro-average (excluding non-used labels)" + 
+    	" P "+f.format (MatrixOps.mean (usedp))  + 
+    	" R "+ f.format (MatrixOps.mean (usedr)) +
+    	" F " + f.format (MatrixOps.mean (usedf)));
 
   }
 

--- a/src/cc/mallet/fst/SimpleTagger.java
+++ b/src/cc/mallet/fst/SimpleTagger.java
@@ -200,7 +200,7 @@ public class SimpleTagger {
 		 "Whether to train", null);
 
 	private static final CommandOption.String testOption = new CommandOption.String
-		(SimpleTagger.class, "test", "lab or seg=start-1.continue-1,...,start-n.continue-n",
+		(SimpleTagger.class, "test", "lab or perclass or seg=start-1.continue-1,...,start-n.continue-n",
 		 true, null,
 		 "Test measuring labeling or segmentation (start-i, continue-i) accuracy", null);
 
@@ -479,7 +479,7 @@ public class SimpleTagger {
 	 *<dd>Whether to train. Default is <code>false</code>.</dd>
 	 *<dt><code>--iterations</code> <em>positive-integer</em></dt>
 	 *<dd>Number of training iterations. Default is 500.</dd>
-	 *<dt><code>--test</code> <code>lab</code> or <code>seg=</code><em>start-1</em><code>.</code><em>continue-1</em><code>,</code>...<code>,</code><em>start-n</em><code>.</code><em>continue-n</em></dt>
+	 *<dt><code>--test</code> <code>lab</code> or <code>perclass</code> or <code>seg=</code><em>start-1</em><code>.</code><em>continue-1</em><code>,</code>...<code>,</code><em>start-n</em><code>.</code><em>continue-n</em></dt>
 	 *<dd>Test measuring labeling or segmentation (<em>start-i</em>, <em>continue-i</em>) accuracy. Default is no testing.</dd>
 	 *<dt><code>--training-proportion</code> <em>number-between-0-and-1</em></dt>
 	 *<dd>Fraction of data to use for training in a random split. Default is 0.5.</dd>
@@ -605,8 +605,9 @@ public class SimpleTagger {
 		if (testOption.value != null) {
 			if (testOption.value.startsWith("lab")) {
 					eval = new TokenAccuracyEvaluator(new InstanceList[] {trainingData, testData}, new String[] {"Training", "Testing"});
-			}
-			else if (testOption.value.startsWith("seg=")) {
+			}else if(testOption.value.startsWith("perclass")){
+					eval = new PerClassAccuracyEvaluator(new InstanceList[] {trainingData, testData}, new String[] {"Training", "Testing"});
+			}else if (testOption.value.startsWith("seg=")) {
 				String[] pairs = testOption.value.substring(4).split(",");
 				if (pairs.length < 1) {
 					commandOptions.printUsage(true);

--- a/src/cc/mallet/types/MatrixOps.java
+++ b/src/cc/mallet/types/MatrixOps.java
@@ -10,6 +10,7 @@ package cc.mallet.types;
 import java.util.Random;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.util.List;
 
 /** 
  *  A class of static utility functions for manipulating arrays of
@@ -310,6 +311,14 @@ public final class MatrixOps
             sum = sum +  v.valueAtLocation(vli);
         }
         return sum;
+    }
+
+    public static Double mean(List<Double> m){
+      double sum = 0;
+      for(Double i : m){
+        sum += i;
+      }
+      return new Double(sum/m.size());
     }
 
     public static double mean (double[] m) {


### PR DESCRIPTION
Added function to calculate mean value for a List<Double> in MatrixOps.

Changed way that PerClassAccuracyEvaluator prints Macro-average for precision, recall and f1. 

Added PerClassAccuracyEvaluator to SimpleTagger's TransducerEvaluator so it can report precision, recall and F1.
