### PR TITLE
#93 HierarchicalLDA class cast exception 

### DIFF
--- a/src/cc/mallet/topics/HierarchicalLDA.java
+++ b/src/cc/mallet/topics/HierarchicalLDA.java
@@ -227,7 +227,8 @@ public class HierarchicalLDA {
 	
 		calculateWordLikelihood(nodeWeights, rootNode, 0.0, typeCounts, newTopicWeights, 0, iteration);
 
-		NCRPNode[] nodes = (NCRPNode[]) nodeWeights.keys().toArray();
+		Object[] objectArray = nodeWeights.keys().toArray();
+		NCRPNode[] nodes = Arrays.copyOf(objectArray, objectArray.length, NCRPNode[].class);
 		double[] weights = new double[nodes.length];
 		double sum = 0.0;
 		double max = Double.NEGATIVE_INFINITY;


### PR DESCRIPTION
used Arrays.copyOf to fix the NCRPNode class cast exception