### PR TITLE
Fix lgtm.com alerts: NaN comparison and correct type casting

### DIFF
--- a/src/cc/mallet/types/GainRatio.java
+++ b/src/cc/mallet/types/GainRatio.java
@@ -242,7 +242,7 @@ public class GainRatio extends RankedFeatureVector
 				
 				
 			}
-			assert(bestSplitPoint != Double.NaN);
+			assert(!Double.isNaN(bestSplitPoint));
 			gainRatios[fi] = featureMaxGainRatio;
 			splitPoints[fi] = bestSplitPoint;
 

--- a/src/cc/mallet/util/PropertyList.java
+++ b/src/cc/mallet/util/PropertyList.java
@@ -80,10 +80,10 @@ public class PropertyList implements Serializable
 				if (obj == null) return 0;
 				// xxx Remove these?  Use might ask for numericIterator expecting to get these (and not!)
 				if (obj instanceof Double) return ((Double)obj).doubleValue();
-				if (obj instanceof Integer) return ((Double)obj).intValue();
-				if (obj instanceof Float) return ((Double)obj).floatValue();
-				if (obj instanceof Short) return ((Double)obj).shortValue();
-				if (obj instanceof Long) return ((Double)obj).longValue();
+				if (obj instanceof Integer) return ((Integer)obj).intValue();
+				if (obj instanceof Float) return ((Float)obj).floatValue();
+				if (obj instanceof Short) return ((Short)obj).shortValue();
+				if (obj instanceof Long) return ((Long)obj).longValue();
 				// xxx? throw new IllegalStateException ("Property is not numeric.");
 				return 0;
 			} else


### PR DESCRIPTION
GainRatio.java: comparing a value to Double.NaN using '!=' operator will always return
true: 'NaN != NaN'. Using Double.isNaN(...) instead. 

More details: https://lgtm.com/projects/g/mimno/Mallet/snapshot/dist-15540021-1490802114895/files/src/cc/mallet/types/GainRatio.java#L245

PropertyList.java: don't cast to Double when it's not a Double. More info: https://lgtm.com/projects/g/mimno/Mallet/snapshot/dist-15540021-1490802114895/files/src/cc/mallet/util/PropertyList.java#L83

There are a total of 185 alerts reported for MALLET on lgtm.com: https://lgtm.com/projects/g/mimno/Mallet/alerts

Tip: enable pull request integration for automatic code review!