### PR TITLE
Types Test Dependency Refactor 

### DIFF
--- a/src/cc/mallet/types/tests/TestAlphabet.java
+++ b/src/cc/mallet/types/tests/TestAlphabet.java
@@ -9,6 +9,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import cc.mallet.types.Alphabet;
 import junit.framework.TestSuite;
+import java.io.IOException;
 
 /**
  * Created: Nov 24, 2004

--- a/src/cc/mallet/types/tests/TestAlphabet.java
+++ b/src/cc/mallet/types/tests/TestAlphabet.java
@@ -5,12 +5,10 @@
    version 1.0, as published by http://www.opensource.org.  For further
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.types.tests;
-
-import junit.framework.*;
-
-import java.io.IOException;
-
+import junit.framework.Test;
+import junit.framework.TestCase;
 import cc.mallet.types.Alphabet;
+import junit.framework.TestSuite;
 
 /**
  * Created: Nov 24, 2004

--- a/src/cc/mallet/types/tests/TestAugmentableFeatureVector.java
+++ b/src/cc/mallet/types/tests/TestAugmentableFeatureVector.java
@@ -10,7 +10,9 @@ import cc.mallet.types.Alphabet;
 import cc.mallet.types.AugmentableFeatureVector;
 import cc.mallet.types.FeatureVector;
 import cc.mallet.types.SparseVector;
-import junit.framework.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Created: Dec 30, 2004
@@ -27,7 +29,7 @@ public class TestAugmentableFeatureVector extends TestCase {
 
   public static Test suite ()
   {
-    return new TestSuite (TestAugmentableFeatureVector.class);
+    return new TestSuite(TestAugmentableFeatureVector.class);
   }
 
   public void testDotProductBinaryToSV ()

--- a/src/cc/mallet/types/tests/TestFeatureSequence.java
+++ b/src/cc/mallet/types/tests/TestFeatureSequence.java
@@ -16,7 +16,10 @@ package cc.mallet.types.tests;
 
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.FeatureSequence;
-import junit.framework.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
 
 public class TestFeatureSequence extends TestCase
 {

--- a/src/cc/mallet/types/tests/TestFeatureVector.java
+++ b/src/cc/mallet/types/tests/TestFeatureVector.java
@@ -17,7 +17,10 @@ package cc.mallet.types.tests;
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.FeatureSequence;
 import cc.mallet.types.FeatureVector;
-import junit.framework.*;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import junit.framework.Test;
+
 
 public class TestFeatureVector extends TestCase
 {

--- a/src/cc/mallet/types/tests/TestHashedSparseVector.java
+++ b/src/cc/mallet/types/tests/TestHashedSparseVector.java
@@ -17,11 +17,8 @@ package cc.mallet.types.tests;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-
 import java.io.File;
 import java.io.IOException;
-
-import cc.mallet.types.DenseVector;
 import cc.mallet.types.HashedSparseVector;
 import cc.mallet.types.SparseVector;
 import cc.mallet.util.FileUtils;

--- a/src/cc/mallet/types/tests/TestIndexedSparseVector.java
+++ b/src/cc/mallet/types/tests/TestIndexedSparseVector.java
@@ -14,12 +14,11 @@
 
 package cc.mallet.types.tests;
 
-import junit.framework.*;
-
+import junit.framework.TestCase;
+import junit.framework.Test;
+import junit.framework.TestSuite;
 import java.io.IOException;
 import java.util.Arrays;
-
-import cc.mallet.types.DenseVector;
 import cc.mallet.types.IndexedSparseVector;
 import cc.mallet.types.SparseVector;
 

--- a/src/cc/mallet/types/tests/TestInstanceListWeights.java
+++ b/src/cc/mallet/types/tests/TestInstanceListWeights.java
@@ -1,12 +1,10 @@
 package cc.mallet.types.tests;
+import cc.mallet.pipe.Noop;
+import cc.mallet.types.Instance;
+import cc.mallet.types.InstanceList;
+import org.junit.Test;
 
-import org.junit.Before; 
-import org.junit.Ignore; 
-import org.junit.Test; 
-import static org.junit.Assert.*;
-
-import cc.mallet.types.*;
-import cc.mallet.pipe.*;
+import static junit.framework.Assert.assertEquals;
 
 public class TestInstanceListWeights {
 	
@@ -16,7 +14,6 @@ public class TestInstanceListWeights {
 		InstanceList instances = new InstanceList(new Noop());
 		Instance instance1 = new Instance("test", null, null, null);
 		Instance instance2 = new Instance("test", null, null, null);
-		Instance instance3 = new Instance("test", null, null, null);
 		
 		instances.add(instance1, 10.0);
 		instances.add(instance2);

--- a/src/cc/mallet/types/tests/TestLabelAlphabet.java
+++ b/src/cc/mallet/types/tests/TestLabelAlphabet.java
@@ -9,11 +9,8 @@ package cc.mallet.types.tests;
 import junit.framework.TestCase;
 import junit.framework.Test;
 import junit.framework.TestSuite;
-
 import java.io.IOException;
 import java.io.Serializable;
-
-import cc.mallet.types.Alphabet;
 import cc.mallet.types.Label;
 import cc.mallet.types.LabelAlphabet;
 

--- a/src/cc/mallet/types/tests/TestLabelVector.java
+++ b/src/cc/mallet/types/tests/TestLabelVector.java
@@ -13,11 +13,11 @@
  */
 
 package cc.mallet.types.tests;
-
-import cc.mallet.types.Label;
 import cc.mallet.types.LabelAlphabet;
 import cc.mallet.types.LabelVector;
-import junit.framework.*;
+import junit.framework.TestCase;
+import junit.framework.Test;
+import junit.framework.TestSuite;
 
 public class TestLabelVector extends TestCase
 {

--- a/src/cc/mallet/types/tests/TestLabelsSequence.java
+++ b/src/cc/mallet/types/tests/TestLabelsSequence.java
@@ -5,15 +5,14 @@
    version 1.0, as published by http://www.opensource.org.  For further
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.types.tests;
-
-import junit.framework.*;
-
 import java.io.IOException;
-
 import cc.mallet.types.Label;
 import cc.mallet.types.LabelAlphabet;
 import cc.mallet.types.Labels;
 import cc.mallet.types.LabelsSequence;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Created: Sep 21, 2004
@@ -48,7 +47,7 @@ public class TestLabelsSequence extends TestCase {
   
   public static Test suite ()
   {
-    return new TestSuite (TestLabelsSequence.class);
+    return new TestSuite(TestLabelsSequence.class);
   }
 
   public static void main (String[] args) throws Throwable

--- a/src/cc/mallet/types/tests/TestMatrix.java
+++ b/src/cc/mallet/types/tests/TestMatrix.java
@@ -13,10 +13,11 @@
  */
 
 package cc.mallet.types.tests;
-
-import cc.mallet.types.DenseVector;
 import cc.mallet.types.SparseVector;
-import junit.framework.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
 
 public class TestMatrix extends TestCase
 {
@@ -35,7 +36,7 @@ public class TestMatrix extends TestCase
 
 	public static Test suite ()
 	{
-		return new TestSuite (TestMatrix.class);
+		return new TestSuite(TestMatrix.class);
 	}
 
 	protected void setUp ()

--- a/src/cc/mallet/types/tests/TestMatrixn.java
+++ b/src/cc/mallet/types/tests/TestMatrixn.java
@@ -9,11 +9,8 @@ package cc.mallet.types.tests;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-
 import java.util.Arrays;
 import java.io.IOException;
-
-import cc.mallet.types.MatrixOps;
 import cc.mallet.types.Matrixn;
 
 /**

--- a/src/cc/mallet/types/tests/TestMultinomial.java
+++ b/src/cc/mallet/types/tests/TestMultinomial.java
@@ -17,7 +17,10 @@ package cc.mallet.types.tests;
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.FeatureSequence;
 import cc.mallet.types.Multinomial;
-import junit.framework.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
 
 public class TestMultinomial extends TestCase
 {
@@ -67,7 +70,7 @@ public class TestMultinomial extends TestCase
 
 	public static Test suite ()
 	{
-		return new TestSuite (TestMultinomial.class);
+		return new TestSuite(TestMultinomial.class);
 	}
 
 	protected void setUp ()

--- a/src/cc/mallet/types/tests/TestPagedInstanceList.java
+++ b/src/cc/mallet/types/tests/TestPagedInstanceList.java
@@ -6,14 +6,13 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.types.tests;
 
-import junit.framework.*;
-
+import cc.mallet.classify.Classifier;
+import cc.mallet.classify.ClassifierTrainer;
+import cc.mallet.classify.MaxEntTrainer;
+import cc.mallet.classify.Trial;
+import cc.mallet.pipe.*;
 import java.io.File;
 import java.util.Iterator;
-
-import cc.mallet.classify.*;
-import cc.mallet.pipe.*;
-import cc.mallet.pipe.iterator.PipeInputIterator;
 import cc.mallet.pipe.iterator.RandomTokenSequenceIterator;
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.Dirichlet;
@@ -21,6 +20,9 @@ import cc.mallet.types.InstanceList;
 import cc.mallet.types.Instance;
 import cc.mallet.types.PagedInstanceList;
 import cc.mallet.util.Randoms;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Created: Apr 19, 2005
@@ -37,7 +39,7 @@ public class TestPagedInstanceList extends TestCase {
 
   public static Test suite ()
   {
-    return new TestSuite (TestPagedInstanceList.class);
+    return new TestSuite(TestPagedInstanceList.class);
   }
 
 
@@ -51,9 +53,9 @@ public class TestPagedInstanceList extends TestCase {
 
   public void testRandomTrained ()
   {
-    Pipe p = new SerialPipes (new Pipe[]	{
-			new TokenSequence2FeatureSequence (),
-			new FeatureSequence2FeatureVector (),
+    Pipe p = new SerialPipes(new Pipe[]	{
+			new TokenSequence2FeatureSequence(),
+			new FeatureSequence2FeatureVector(),
 			new Target2Label()});
 
     double testAcc1 = testRandomTrainedOn (new InstanceList (p));
@@ -63,7 +65,7 @@ public class TestPagedInstanceList extends TestCase {
 
   private double testRandomTrainedOn (InstanceList training)
   {
-    ClassifierTrainer trainer = new MaxEntTrainer ();
+    ClassifierTrainer trainer = new MaxEntTrainer();
 
     Alphabet fd = dictOfSize (3);
     String[] classNames = new String[] {"class0", "class1", "class2"};
@@ -84,7 +86,7 @@ public class TestPagedInstanceList extends TestCase {
 
     System.out.println ("Accuracy on training set:");
     System.out.println (classifier.getClass().getName()
-                          + ": " + new Trial (classifier, training).getAccuracy());
+                          + ": " + new Trial(classifier, training).getAccuracy());
 
     System.out.println ("Accuracy on testing set:");
     double testAcc = new Trial (classifier, testing).getAccuracy();

--- a/src/cc/mallet/types/tests/TestRankedFeatureVector.java
+++ b/src/cc/mallet/types/tests/TestRankedFeatureVector.java
@@ -14,8 +14,12 @@
 
 package cc.mallet.types.tests;
 
-import cc.mallet.types.*;
-import junit.framework.*;
+
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.RankedFeatureVector;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 public class TestRankedFeatureVector extends TestCase
 {
@@ -36,7 +40,7 @@ public class TestRankedFeatureVector extends TestCase
 
 	public static Test suite ()
 	{
-		return new TestSuite (TestRankedFeatureVector.class);
+		return new TestSuite(TestRankedFeatureVector.class);
 	}
 
 	protected void setUp ()

--- a/src/cc/mallet/types/tests/TestSerializable.java
+++ b/src/cc/mallet/types/tests/TestSerializable.java
@@ -5,10 +5,11 @@
    version 1.0, as published by http://www.opensource.org.  For further
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.types.tests;
-
-import junit.framework.*;
-
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 import java.io.*;
+
 
 /**
  * Static utility for testing serializable classes in MALLET.
@@ -27,7 +28,7 @@ public class TestSerializable extends TestCase {
 
   public static Test suite ()
   {
-    return new TestSuite (TestSerializable.class);
+    return new TestSuite(TestSerializable.class);
   }
 
   /**

--- a/src/cc/mallet/types/tests/TestSparseMatrixn.java
+++ b/src/cc/mallet/types/tests/TestSparseMatrixn.java
@@ -12,11 +12,7 @@ import junit.framework.TestSuite;
 
 import java.util.Arrays;
 import java.io.IOException;
-
-import cc.mallet.types.MatrixOps;
-import cc.mallet.types.Matrixn;
 import cc.mallet.types.SparseMatrixn;
-
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.DoubleArrayList;
 

--- a/src/cc/mallet/types/tests/TestSparseVector.java
+++ b/src/cc/mallet/types/tests/TestSparseVector.java
@@ -15,10 +15,11 @@
 package cc.mallet.types.tests;
 
 import java.io.*;
-
 import cc.mallet.types.DenseVector;
 import cc.mallet.types.SparseVector;
-import junit.framework.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 public class TestSparseVector extends TestCase
 {
@@ -231,7 +232,7 @@ public class TestSparseVector extends TestCase
 	
 	public static Test suite ()
 	{
-		return new TestSuite (TestSparseVector.class);
+		return new TestSuite(TestSparseVector.class);
 	}
 
 	protected void setUp ()

--- a/src/cc/mallet/types/tests/TestToken.java
+++ b/src/cc/mallet/types/tests/TestToken.java
@@ -14,16 +14,14 @@
 
 package cc.mallet.types.tests;
 
-import junit.framework.*;
-
-
 import java.net.URI;
-import java.net.URL;
 import java.io.File;
-
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.FeatureVector;
 import cc.mallet.types.Token;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 public class TestToken extends TestCase
 {
@@ -70,7 +68,7 @@ public class TestToken extends TestCase
 
 	public static Test suite ()
 	{
-		return new TestSuite (TestToken.class);
+		return new TestSuite(TestToken.class);
 	}
 
 	protected void setUp ()


### PR DESCRIPTION
Got rid of import wildcards, unused imports, and unused variables in the tests for the Types package. 