### PR TITLE
Improvements and bugfixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -58,7 +58,8 @@
                 classpathref="project.classpath"
                 debug="true"
                 deprecation="off"
-                listfiles="no">
+                listfiles="no"
+                includeantruntime="false">
             <src path="${src}"/>
             <include name="cc/**/*.java"/>
             <!-- compilerarg value="-Xlint:unchecked"/ -->
@@ -76,7 +77,7 @@
        includeantruntime="false">
        <src path="src"/>
        <compilerclasspath>
-         <pathelement location="lib/errorprone.jar"/>
+           <pathelement location="lib/error_prone_ant-2.2.0.jar"/>
        </compilerclasspath>
      </javac>
     </target>

--- a/lib/errorprone.jar
+++ b/lib/errorprone.jar
@@ -1,1 +1,0 @@
-error_prone_ant-2.2.0.jar

--- a/src/cc/mallet/fst/CRFTrainerByThreadedLabelLikelihood.java
+++ b/src/cc/mallet/fst/CRFTrainerByThreadedLabelLikelihood.java
@@ -167,7 +167,7 @@ public class CRFTrainerByThreadedLabelLikelihood extends TransducerTrainer imple
 		boolean converged = false;
 		for (int i = 0; i < trainingProportions.length; i++) {
 			assert (trainingProportions[i] <= 1.0);
-			logger.info ("Training on "+trainingProportions[i]+"% of the data this round.");
+			logger.info("Training on " + (trainingProportions[i] * 100) + "% of the data this round.");
 			if (trainingProportions[i] == 1.0) {
 				converged = this.train (training, numIterationsPerProportion);
 			}

--- a/src/cc/mallet/pipe/CharSequenceReplaceHtmlEntities.java
+++ b/src/cc/mallet/pipe/CharSequenceReplaceHtmlEntities.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import cc.mallet.types.Instance;
 
 /**
- * Be careful here: this pipe must be applied before {@link CharSequenceToLowercase} because it is
+ * Be careful here: this pipe must be applied before {@link CharSequenceLowercase} because it is
  * case sensitive.
  */
 public class CharSequenceReplaceHtmlEntities extends Pipe implements Serializable {

--- a/src/cc/mallet/pipe/StringIterator.java
+++ b/src/cc/mallet/pipe/StringIterator.java
@@ -8,7 +8,15 @@
 
 package cc.mallet.pipe;
 
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Java implementation of Jonathan Wood's "Text Parsing Helper Class".
@@ -18,17 +26,996 @@ import java.util.Iterator;
  */
 final public class StringIterator implements Iterator<Character> {
 
+  public static final char CR = '\n';
+  public static final char LF = '\r';
+  public static final char SPACE = ' ';
+  public static final String TAG_TABLE_ROW = "TABLE_ROW | ";
+  public static final String TAG_SECTION_HEADER = "SECTION_HEADER | ";
+  public static final String TAG_LIST_ITEM = "LIST_ITEM | ";
+  public static final String TAG_TEXT = "TEXT | ";
+  public static final String TAG_EMPTY_ROW = "EMPTY_ROW | ";
+  public static final String TAG_SENTENCE = "SENTENCE | ";
+
+  private static final Pattern TABLE_PATTERN =
+      Pattern.compile("(\\s{2,}\\p{L}+)|(\\s{2,}[0-9]+)", Pattern.CASE_INSENSITIVE);
+
   private String text_ = null;
   private int position_ = 0;
 
   public StringIterator(String text) {
-    reset(text);
+    this(text, false);
+  }
+
+  protected StringIterator(String text, boolean clean) {
+    reset(clean ? clean(text) : text);
+  }
+
+  /**
+   * Split texts extracted with XPDF's pdftotext or Apache Tika into a list of sentences.
+   *
+   * @param text text.
+   * @param addTags true iif each sentence must be prefixed by a type chosen between EMPTY_ROW,
+   *        TABLE_ROW, SECTION_HEADER or TAG_SENTENCE.
+   * @return A list of sentences.
+   */
+  public static List<String> sentences(String text, boolean addTags) {
+
+    List<String> rows = new ArrayList<>();
+    StringIterator iterator = new StringIterator(clean(text, true), false);
+
+    while (iterator.hasNext()) {
+      int begin = iterator.position();
+      iterator.moveToEndOfLine();
+      int end = iterator.position();
+      iterator.movePastWhitespace();
+      rows.add(iterator.extract(begin, end));
+    }
+
+    List<String> sentences = new ArrayList<>();
+
+    for (int i = 0; i < rows.size(); i++) {
+
+      String row = rows.get(i);
+      if (row == null || isBlank(row)) { // Discard blank rows
+        continue;
+      }
+      if (row.startsWith(TAG_EMPTY_ROW)) { // Empty row
+        sentences.add(addTags ? row : row.substring(TAG_EMPTY_ROW.length()));
+        continue;
+      }
+      if (row.startsWith(TAG_TABLE_ROW)) { // Table row
+        sentences.add(addTags ? row : row.substring(TAG_TABLE_ROW.length()));
+        continue;
+      }
+      if (row.startsWith(TAG_SECTION_HEADER)) { // Section header
+        sentences.add(addTags ? row : row.substring(TAG_SECTION_HEADER.length()));
+        continue;
+      }
+
+      // Remove tags
+      String curTag;
+      if (row.startsWith(TAG_LIST_ITEM)) {
+        row = row.substring(TAG_LIST_ITEM.length());
+        curTag = TAG_SENTENCE; // Not a bug!
+      } else if (row.startsWith(TAG_TEXT)) {
+        row = row.substring(TAG_TEXT.length());
+        curTag = TAG_SENTENCE;
+      } else {
+        curTag = "";
+        continue;
+      }
+
+      // Parse each row as a list of sentences
+      int isInBracket = 0;
+      StringBuilder builder = new StringBuilder();
+      StringIterator iter = new StringIterator(row, false);
+
+      while (iter.hasNext()) {
+
+        char c = iter.next();
+        if (c == CR || c == LF) {
+          sentences.add(addTags ? curTag + builder.toString() : builder.toString());
+          isInBracket = 0;
+          builder.setLength(0);
+          continue;
+        }
+        if (isLeftBracket(c)) {
+          isInBracket++;
+        }
+        if (isRightBracket(c)) {
+          isInBracket--;
+        }
+        if (isInBracket != 0 || !isTerminalMark(c)) {
+          builder.append(c);
+          continue;
+        }
+        if (c != '.') {
+          builder.append(c);
+          sentences.add(addTags ? curTag + builder.toString() : builder.toString());
+          isInBracket = 0;
+          builder.setLength(0);
+          continue;
+        }
+        if (builder.length() == 0) { // single dot
+          builder.append(c);
+          sentences.add(addTags ? curTag + builder.toString() : builder.toString());
+          isInBracket = 0;
+          builder.setLength(0);
+          continue;
+        }
+
+        char prev = builder.charAt(builder.length() - 1);
+        char next = iter.peek();
+
+        builder.append(c);
+
+        // 3.4 or .4
+        if ((Character.isDigit(prev) || Character.isWhitespace(prev)) && Character.isDigit(next)) {
+          continue;
+        }
+
+        int gapBegins = iter.position();
+        while (iter.hasNext() && isWhitespace(iter.peek())) {
+          c = iter.next();
+        }
+        int gapEnds = iter.position();
+
+        String gap = gapBegins < gapEnds ? iter.extract(gapBegins, gapEnds) : "";
+        next = iter.peek();
+
+        if (Character.isLetter(prev) && Character.isLetter(next)) {
+
+          // i.e.
+          if (prev == Character.toLowerCase(prev) && next == Character.toLowerCase(next)) {
+            if (!gap.contains("\n")) {
+              continue;
+            }
+          }
+
+          // C.H.U.
+          if (prev == Character.toUpperCase(prev) && next == Character.toUpperCase(next)) {
+            if (!gap.contains("\n")) {
+              continue;
+            }
+          }
+        }
+
+        sentences.add(addTags ? curTag + builder.toString() : builder.toString());
+        isInBracket = 0;
+        builder.setLength(0);
+      }
+
+      if (builder.length() > 0) {
+        sentences.add(addTags ? curTag + builder.toString() : builder.toString());
+      }
+    }
+    return sentences;
+  }
+
+  /**
+   * Remove useless CR/LF characters. A CR/LF character is "useless" if it is inside a paragraph for
+   * formatting purpose only (e.g. it does not signify the end of the paragraph).
+   *
+   * Works quite well with Apache Tika and XPDF's pdf2text when the -layout option activated.
+   *
+   * This method should NEVER be called directly. This method is "public" for testing purposes only.
+   *
+   * @param text text.
+   * @return trimmed text.
+   */
+  public static String clean(String text) {
+    return clean(text, false);
+  }
+
+  /**
+   * Remove useless CR/LF characters. A CR/LF character is "useless" if it is inside a paragraph for
+   * formatting purpose only (e.g. it does not signify the end of the paragraph).
+   *
+   * Works quite well with Apache Tika and XPDF's pdf2text when the -layout option activated.
+   *
+   * @param text text.
+   * @param addTags true iif each row must be prefixed by its type.
+   * @return trimmed text.
+   */
+  private static String clean(String text, boolean addTags) {
+
+    // Preconditions.checkArgument(!Strings.isNullOrEmpty(text));
+
+    if (text == null) {
+      return "";
+    }
+
+    char[] linebreaks = new char[] {CR, LF};
+
+    String rows = tagRows(text);
+    StringBuilder builder = new StringBuilder(text.length());
+    StringIterator iterator = new StringIterator(rows);
+    String rowBeforePrev = null;
+    String rowPrev = null;
+
+    while (iterator.hasNext()) {
+
+      int begin = iterator.position();
+      iterator.moveToEndOfLine();
+      int end = iterator.position();
+
+      String rowCur = iterator.extract(begin, end);
+      iterator.movePast(linebreaks); // move to the beginning of the next row
+
+      if (!rowCur.startsWith(TAG_EMPTY_ROW)) {
+        mergeRows(builder, rowBeforePrev, rowPrev, rowCur, addTags);
+      }
+
+      rowBeforePrev = rowPrev;
+      rowPrev = rowCur;
+    }
+    return builder.toString().trim();
+  }
+
+  /**
+   * Prefix each row extracted either by Apache Tika or XPDF with a class : TABLE_ROW (this row
+   * belongs to a table), SECTION_HEADER (this row is a header), LIST_ITEM (this row is a list
+   * item), TEXT (this row is plain text).
+   *
+   * @param text text.
+   * @return tagged rows.
+   */
+  private static String tagRows(String text) {
+
+    // Preconditions.checkArgument(!Strings.isNullOrEmpty(text));
+
+    if (text == null) {
+      return "";
+    }
+
+    char[] linebreaks = new char[] {CR, LF};
+
+    text = normalize(text);
+    Set<String> tables =
+        tables(text).stream().flatMap(Collection::stream).collect(Collectors.toSet());
+    StringBuilder builder = new StringBuilder(text.length());
+    StringIterator iterator = new StringIterator(text);
+
+    while (iterator.hasNext()) {
+
+      int begin = iterator.position();
+      iterator.moveToEndOfLine();
+      int end = iterator.position();
+
+      String rowCur = iterator.extract(begin, end);
+      iterator.movePast(linebreaks); // move to the beginning of the next row
+
+      String eol = iterator.extract(end, iterator.position());
+
+      if (tables.contains(rowCur)) {
+        builder.append(TAG_TABLE_ROW);
+        builder.append(rowCur);
+      } else if (isSectionHeader(rowCur)) {
+        builder.append(TAG_SECTION_HEADER);
+        builder.append(rowCur);
+      } else if (isListEntry(rowCur)) {
+        builder.append(TAG_LIST_ITEM);
+        builder.append(rowCur);
+      } else {
+        builder.append(TAG_TEXT);
+        builder.append(rowCur);
+      }
+
+      int nbLinebreaks = 0;
+      for (int i = 0; eol != null && i < eol.length(); i++) {
+        if (eol.charAt(i) == CR) {
+          nbLinebreaks++;
+        }
+      }
+
+      builder.append(CR);
+      if (nbLinebreaks >= 2) {
+        builder.append(TAG_EMPTY_ROW);
+        builder.append(CR);
+      }
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Merge rows.
+   *
+   * @param builder
+   * @param rowPrev
+   * @param rowCur
+   * @param keepRowTags
+   */
+  private static void mergeRows(StringBuilder builder, String rowBeforePrev, String rowPrev,
+      String rowCur, boolean keepRowTags) {
+
+    // Preconditions.checkNotNull(builder);
+    // Preconditions.checkNotNull(rowCur);
+
+    String row = rowCur.substring(rowCur.indexOf(" | ") + 3);
+
+    if (rowPrev == null) {
+      builder.append(keepRowTags ? rowCur : row);
+    } else {
+
+      // prev = TAG_LIST_ITEM && cur = TAG_TEXT
+      // beforePrev = TAG_LIST_ITEM && prev = TAG_EMPTY_ROW && cur = TAG_TEXT
+      boolean isListItem = ((rowBeforePrev != null && rowBeforePrev.startsWith(TAG_LIST_ITEM)
+          && rowPrev.startsWith(TAG_EMPTY_ROW)) || rowPrev.startsWith(TAG_LIST_ITEM))
+          && rowCur.startsWith(TAG_TEXT);
+
+      // prev = TAG_TEXT && cur = TAG_TEXT
+      // beforePrev = TAG_TEXT && prev = TAG_EMPTY_ROW && cur = TAG_TEXT
+      boolean isParagraph = ((rowBeforePrev != null && rowBeforePrev.startsWith(TAG_TEXT)
+          && rowPrev.startsWith(TAG_EMPTY_ROW)) || rowPrev.startsWith(TAG_TEXT))
+          && rowCur.startsWith(TAG_TEXT);
+
+      if (isListItem || isParagraph) {
+
+        boolean hasEmptyRow;
+        String prev;
+        String cur;
+
+        if (!rowPrev.startsWith(TAG_EMPTY_ROW)) {
+
+          // prev = TAG_TEXT && cur = TAG_TEXT
+          // prev = TAG_LIST_ITEM && cur = TAG_TEXT
+
+          hasEmptyRow = false;
+          prev = lastToken(rowPrev.substring(rowPrev.indexOf(" | ") + 3));
+          cur = firstToken(row);
+        } else {
+
+          // beforePrev = TAG_TEXT && prev = TAG_EMPTY_ROW && cur = TAG_TEXT
+          // beforePrev = TAG_LIST_ITEM && prev = TAG_EMPTY_ROW && cur = TAG_TEXT
+
+          hasEmptyRow = true;
+          prev = lastToken(rowBeforePrev.substring(rowBeforePrev.indexOf(" | ") + 3));
+          cur = firstToken(row);
+        }
+
+        if (isLowerCase(cur) && isLowerCase(prev)
+        /* && !isTerminalMark(prev.charAt(prev.length() - 1)) */) {
+
+          // i.e. \n véhicule
+          // véhicule \n acquis
+          builder.append(SPACE);
+          builder.append(trimLeft(row));
+        } else if (isLowerCase(cur) && isUpperCase(prev)
+            && !isTerminalMark(prev.charAt(prev.length() - 1)) && !hasEmptyRow) {
+
+          // TTC \n annuelle
+          builder.append(SPACE);
+          builder.append(trimLeft(row));
+        } else if (isLowerCase(cur) && isCapitalized(prev)
+            && !isTerminalMark(prev.charAt(prev.length() - 1)) && !hasEmptyRow) {
+
+          // Topic \n modeling algorithms
+          builder.append(SPACE);
+          builder.append(trimLeft(row));
+        } else if (isCapitalized(cur) && isLowerCase(prev)
+            && !isTerminalMark(prev.charAt(prev.length() - 1)) && !hasEmptyRow) {
+
+          if (nbLetters(prev) > 0) {
+
+            // latent \n Dirichlet allocation
+            builder.append(SPACE);
+            builder.append(trimLeft(row));
+          } else {
+
+            // Note de R10 rédigée le 25/10/2000 \n Objet : Observation sur l'individu Dumont
+            builder.append(CR);
+            builder.append(keepRowTags ? rowCur : row);
+          }
+        } else {
+          builder.append(CR);
+          builder.append(keepRowTags ? rowCur : row);
+        }
+      } else {
+        builder.append(CR);
+        builder.append(keepRowTags ? rowCur : row);
+      }
+    }
+  }
+
+  /**
+   * Normalize quotation marks and apostrophes.
+   *
+   * @param text document.
+   * @return A normalized text.
+   */
+  public static String normalize(String text) {
+
+    // Preconditions.checkArgument(!Strings.isNullOrEmpty(text));
+
+    StringBuilder builder = new StringBuilder(text.length());
+    StringIterator iterator = new StringIterator(text);
+
+    while (iterator.hasNext()) {
+      char c = iterator.next();
+      if (isApostrophe(c)) {
+        builder.append('\'');
+      } else if (isSingleQuotationMark(c)) {
+        builder.append('\'');
+      } else if (isDoubleQuotationMark(c)) {
+        builder.append('"');
+      } else if (c == '\u00a0' /* non-breaking space */) {
+        builder.append(SPACE);
+      } else {
+        if (c != '\r' || iterator.peek() != '\n') { // convert Windows EOL to Unix EOL
+          builder.append(c);
+        }
+      }
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Extract tables using a regular expression. A row belongs to a table if it contains at least
+   * three columns. Kind of.
+   *
+   * Works quite well with XPDF's pdf2text when the -layout option activated.
+   *
+   * @param text document.
+   * @return A list of tables.
+   */
+  private static List<List<String>> tables(String text) {
+
+    // Preconditions.checkArgument(!Strings.isNullOrEmpty(text));
+
+    List<List<String>> tables = new ArrayList<>();
+    StringIterator iterator = new StringIterator(text);
+    List<String> rows = new ArrayList<>();
+
+    while (iterator.hasNext()) {
+
+      int begin = iterator.position();
+      iterator.moveToEndOfLine();
+      int end = iterator.position();
+      iterator.next();
+
+      String row = iterator.extract(begin, end);
+      if (row.isEmpty()) {
+        continue;
+      }
+
+      Matcher matcher = TABLE_PATTERN.matcher(row);
+      int count = 0;
+
+      while (matcher.find()) {
+        count++;
+      }
+
+      if (count >= 2) {
+        rows.add(row);
+      } else if (count >= 1) {
+        if (!rows.isEmpty()) {
+          rows.add(row);
+        }
+      } else {
+        if (!rows.isEmpty()) {
+          tables.add(rows);
+        }
+        rows = new ArrayList<>();
+      }
+    }
+
+    if (rows.size() >= 2) {
+      tables.add(rows);
+    }
+    return tables;
+  }
+
+  /**
+   * Check if a row is a section header.
+   *
+   * @param rowCur current row.
+   * @return true iif the row is likely a section header.
+   */
+  private static boolean isSectionHeader(String rowCur) {
+
+    // Preconditions.checkNotNull(row);
+
+    if (isUpperCase(rowCur)) {
+      return true;
+    }
+    if (isListEntry(rowCur)) { // Heuristic for header such as "1. Introduction"
+      return Character.isDigit((int) rowCur.charAt(0));
+    }
+    return false;
+  }
+
+  /**
+   * Check if a row is a list entry.
+   *
+   * @param row row.
+   * @return true iif the row is likely a list entry.
+   */
+  private static boolean isListEntry(String row) {
+
+    // Preconditions.checkNotNull(row);
+
+    StringIterator iterator = new StringIterator(row);
+    while (iterator.hasNext()) {
+
+      char c = iterator.next();
+      if (!isWhitespace(c)) {
+
+        // Here, c is the first non-whitespace character of the row.
+
+        // Simple case : list mark (ex: - or • or =>)
+        if (isListMark(c)) {
+          return true;
+        }
+
+        // Move to the first whitespace character
+        int begin = iterator.position() - 1;
+        while (iterator.hasNext() && !isWhitespace(iterator.peek())) {
+          c = iterator.next();
+        }
+        int end = iterator.position();
+
+        // The bullet is probably a special character
+        if ((end - begin) <= 1 && !Character.isLetterOrDigit((int) c) && !isLeftBracket(c)
+            && !isRightBracket(c) && !isQuotationMark(c)) {
+          return true;
+        }
+
+        // Here, the bullet is probably a group of digits/letters
+        // Move to the next non digit/letter character
+        while (iterator.hasNext() && (isWhitespace(iterator.peek())
+            || !Character.isLetterOrDigit((int) iterator.peek()))) {
+          c = iterator.next();
+        }
+        end = iterator.position();
+
+        // Complex case : alpha-numerical bullets (ex: 3. or 3) or 3/ or 3- or 3°)
+        String mark = iterator.extract(begin, end).trim();
+        if (mark != null && !mark.isEmpty()) {
+
+          char firstChar = mark.charAt(0);
+          char lastChar = mark.charAt(mark.length() - 1);
+
+          if (mark.length() <= 10) { // alpha-numerical bullets should be short!
+
+            // alpha-numerical bullets should start either with a number or a letter
+            if (Character.isLetterOrDigit((int) firstChar)) {
+
+              // alpha-numerical bullets should end with a mark
+              if (isListMark(lastChar) || lastChar == '/' || lastChar == '°' || lastChar == '=') {
+                return true;
+              }
+
+              // An attempt to differentiate "a." from "voiture." and "a)" from "voiture)"
+              if (isRightBracket(lastChar) || lastChar == '.') {
+
+                int hasDots = 0;
+                int hasLetters = 0;
+                int hasDigits = 0;
+
+                for (int i = 0; i < mark.length() - 1 /* skip the last dot */; i++) {
+                  if (Character.isLetter((int) mark.charAt(i))) {
+                    hasDigits++;
+                  } else if (Character.isDigit((int) mark.charAt(i))) {
+                    hasLetters++;
+                  } else if (mark.charAt(i) == '.') {
+                    hasDots++;
+                  }
+                }
+                return hasDots > 0 || (hasLetters == 0 && hasDigits <= 2)
+                    || (hasDigits == 0 && hasLetters <= 2);
+              }
+            }
+          }
+        }
+        return false;
+      }
+    }
+    return false;
+  }
+
+  private static String firstToken(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    s = trimLeft(s);
+
+    int i = 0;
+    for (; i < s.length(); i++) {
+      int c = s.codePointAt(i);
+      if (isWhitespace(c)) {
+        break;
+      }
+    }
+    return s.substring(0, i);
+  }
+
+  private static String lastToken(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    s = trimRight(s);
+
+    int i = s.length() - 1;
+    for (; i >= 0; i--) {
+      int c = s.codePointAt(i);
+      if (isWhitespace(c)) {
+        break;
+      }
+    }
+    return s.substring(i + 1);
+  }
+
+  /**
+   * Compute the number of letters.
+   *
+   * @param s string.
+   * @return the number of letters.
+   */
+  public static int nbLetters(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    int nbLetters = 0;
+
+    for (int i = 0; i < s.length(); i++) {
+      int c = s.codePointAt(i);
+      if (Character.isLetter(c)) {
+        nbLetters++;
+      }
+    }
+    return nbLetters;
+  }
+
+  /**
+   * Compute the number of digits.
+   *
+   * @param s string.
+   * @return the number of letters.
+   */
+  public static int nbDigits(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    int nbDigits = 0;
+
+    for (int i = 0; i < s.length(); i++) {
+      int c = s.codePointAt(i);
+      if (Character.isDigit(c)) {
+        nbDigits++;
+      }
+    }
+    return nbDigits;
+  }
+
+  /**
+   * Remove whitespace prefix from string.
+   *
+   * @param s string.
+   * @return string without whitespaces at the beginning.
+   */
+  public static String trimLeft(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    for (int i = 0; i < s.length(); i++) {
+      int c = s.codePointAt(i);
+      if (!isWhitespace(c)) {
+        return i == 0 ? s : s.substring(i);
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Remove whitespace suffix from string.
+   *
+   * @param s string.
+   * @return string without whitespaces at the end.
+   */
+  public static String trimRight(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    for (int i = s.length() - 1; i >= 0; i--) {
+      int c = s.codePointAt(i);
+      if (!isWhitespace(c)) {
+        return i == s.length() - 1 ? s : s.substring(0, i + 1);
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Check if a string is blank.
+   *
+   * @param s string.
+   * @return true iif s is only made of whitespace characters.
+   */
+  public static boolean isBlank(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    for (int i = 0; i < s.length(); i++) {
+      int c = s.codePointAt(i);
+      if (!isWhitespace(c)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Check if a string is capitalized.
+   *
+   * @param s string.
+   * @return true iif s starts with an upper case character and all other characters are lower case.
+   */
+  public static boolean isCapitalized(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    boolean isFirst = true;
+
+    for (int i = 0; i < s.length(); i++) {
+      int c = s.codePointAt(i);
+      if (isFirst) {
+        if (c != Character.toUpperCase(c)) {
+          return false;
+        }
+        isFirst = isWhitespace(c);
+      } else {
+        if (c != Character.toLowerCase(c)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Check if a string is upper case.
+   *
+   * @param s string.
+   * @return true iif s is only made of upper case characters.
+   */
+  public static boolean isUpperCase(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    for (int i = 0; i < s.length(); i++) {
+      int c = s.codePointAt(i);
+      if (c != Character.toUpperCase(c)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Check if a string is lower case.
+   *
+   * @param s string.
+   * @return true iif s is only made of lower case characters.
+   */
+  public static boolean isLowerCase(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    for (int i = 0; i < s.length(); i++) {
+      int c = s.codePointAt(i);
+      if (c != Character.toLowerCase(c)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * A string normalizer which performs the following steps:
+   * <ol>
+   * <li>Unicode canonical decomposition ({@link Normalizer.Form#NFD})</li>
+   * <li>Removal of diacritical marks</li>
+   * <li>Unicode canonical composition ({@link Normalizer.Form#NFC})</li>
+   * </ol>
+   */
+  public static String removeDiacriticalMarks(String s) {
+
+    // Preconditions.checkNotNull(s);
+
+    String decomposed = Normalizer.normalize(s, Normalizer.Form.NFD);
+    Pattern diacriticals = Pattern.compile("\\p{InCombiningDiacriticalMarks}");
+    Matcher matcher = diacriticals.matcher(decomposed);
+    String noDiacriticals = matcher.replaceAll("");
+    return Normalizer.normalize(noDiacriticals, Normalizer.Form.NFC);
+  }
+
+  /**
+   * Check if a character is a whitespace. This method takes into account Unicode space characters.
+   *
+   * @param c character as a unicode code point.
+   * @return true if c is a space character.
+   */
+  public static boolean isWhitespace(int c) {
+    return Character.isWhitespace(c) || Character.isSpaceChar(c);
+  }
+
+  /**
+   * Check if a character is a punctuation in the standard ASCII.
+   *
+   * @param c character.
+   * @return true iif c is a punctuation character.
+   */
+  public static boolean isPunctuation(char c) {
+    return isInRange(c, '!', '/') || isInRange(c, ':', '@') || isInRange(c, '[', '`')
+        || isInRange(c, '{', '~');
+  }
+
+  /**
+   * Check if a character is a punctuation in Unicode.
+   *
+   * @param c character.
+   * @return true iif c is a punctuation character.
+   */
+  public static boolean isGeneralPunctuation(char c) {
+    return isInRange(c, '\u2000', '\u206F');
+  }
+
+  /**
+   * Check if a character is a CJK symbol.
+   *
+   * @param c character.
+   * @return true iif c is a CJK symbol.
+   */
+  public static boolean isCjkSymbol(char c) {
+    return isInRange(c, '\u3001', '\u3003') || isInRange(c, '\u3008', '\u301F');
+  }
+
+  /**
+   * Check if a character is a currency symbol.
+   *
+   * @param c character.
+   * @return true iif c is a currency symbol.
+   */
+  public static boolean isCurrency(char c) {
+    return (c == '$') || isInRange(c, '\u00A2', '\u00A5') || isInRange(c, '\u20A0', '\u20CF');
+  }
+
+  /**
+   * Check if a character is an arrow symbol.
+   *
+   * @param c character.
+   * @return true iif c is an arrow symbol.
+   */
+  public static boolean isArrow(char c) {
+    return isInRange(c, '\u2190', '\u21FF') || isInRange(c, '\u27F0', '\u27FF')
+        || isInRange(c, '\u2900', '\u297F');
+  }
+
+  /**
+   * Check if a character is an hyphen.
+   *
+   * @param c character.
+   * @return true iif c is an hyphen.
+   */
+  public static boolean isHyphen(char c) {
+    return c == '-' || isInRange(c, '\u2010', '\u2014');
+  }
+
+  /**
+   * Check if a character is an apostrophe.
+   *
+   * @param c character.
+   * @return true iif c is an apostrophe.
+   */
+  public static boolean isApostrophe(char c) {
+    return c == '\'' || c == '\u2019';
+  }
+
+  /**
+   * Check if a character is a list mark.
+   *
+   * @param c character.
+   * @return true iif c is a list mark.
+   */
+  public static boolean isListMark(char c) {
+    return c == '-' || c == '\uF0F0' || c == '\u2022' || c == '\u2023' || c == '\u203B'
+        || c == '\u2043';
+  }
+
+  /**
+   * Check if a character is a final mark.
+   *
+   * @param c character.
+   * @return true iif c is a final mark.
+   */
+  public static boolean isTerminalMark(char c) {
+    return c == '.' || c == '?' || c == '!' || c == '\u203C' || isInRange(c, '\u2047', '\u2049');
+  }
+
+  /**
+   * Check if a character is a separator.
+   *
+   * @param c character.
+   * @return true iif c is a separator.
+   */
+  public static boolean isSeparatorMark(char c) {
+    return c == ',' || c == ';' || c == ':' || c == '|' || c == '/' || c == '\\';
+  }
+
+  /**
+   * Check if a character is a quotation mark.
+   *
+   * @param c character.
+   * @return true iif c is a quotation mark.
+   */
+  public static boolean isQuotationMark(char c) {
+    return isSingleQuotationMark(c) || isDoubleQuotationMark(c);
+  }
+
+  /**
+   * Check if a character is a single quotation mark.
+   *
+   * @param c character.
+   * @return true iif c is a single quotation mark.
+   */
+  public static boolean isSingleQuotationMark(char c) {
+    return c == '\'' || c == '`' || isInRange(c, '\u2018', '\u201B');
+  }
+
+  /**
+   * Check if a character is a double quotation mark.
+   *
+   * @param c character.
+   * @return true iif c is a double quotation mark.
+   */
+  public static boolean isDoubleQuotationMark(char c) {
+    return c == '"' || c == '«' || c == '»' || isInRange(c, '\u201C', '\u201F');
+  }
+
+  /**
+   * Check if a character is a bracket.
+   *
+   * @param c character.
+   * @return true iif c is a bracket.
+   */
+  public static boolean isBracket(char c) {
+    return isLeftBracket(c) || isRightBracket(c);
+  }
+
+  /**
+   * Check if a character is a left bracket.
+   *
+   * @param c character.
+   * @return true iif c is a left bracket.
+   */
+  public static boolean isLeftBracket(char c) {
+    return c == '(' || c == '{' || c == '[' || c == '<';
+  }
+
+  /**
+   * Check if a character is a right bracket.
+   *
+   * @param c character.
+   * @return true iif c is a right bracket.
+   */
+  public static boolean isRightBracket(char c) {
+    return c == ')' || c == '}' || c == ']' || c == '>';
+  }
+
+  /**
+   * Check if a character is contained in an interval.
+   *
+   * @param c character.
+   * @param start lower bound (inclusive).
+   * @param end upper bound (inclusive).
+   * @return true iif c is contained in [start, end].
+   */
+  private static boolean isInRange(char c, int start, int end) {
+    return start <= c && c <= end;
   }
 
   /**
    * Sets the current document and resets the current position to the start of it.
-   *
-   * @param text
    */
   public void reset(String text) {
 
@@ -40,10 +1027,6 @@ final public class StringIterator implements Iterator<Character> {
 
     text_ = text;
     position_ = 0;
-  }
-
-  public boolean hasNextSentence() {
-    return hasNext();
   }
 
   @Override
@@ -65,120 +1048,6 @@ final public class StringIterator implements Iterator<Character> {
    */
   public boolean isEndOfText() {
     return position_ >= text_.length();
-  }
-
-  /**
-   * Instead of iterating on characters, iterate on sentences. Words between parenthesis and
-   * brackets are removed.
-   *
-   * @return a sentence.
-   */
-  public String nextSentence() {
-
-    int inParenthesis = -1;
-    int inBrackets = -1;
-
-    StringBuilder builder = new StringBuilder();
-
-    while (hasNext()) {
-
-      char c = next();
-      switch (c) {
-        case '\n':
-        case '\r':
-          if (inParenthesis < 0 && inBrackets < 0) {
-
-            // Heuristic: we guess that a new sentence starts after at least 2 line breaks. Very
-            // useful for dealing with bullet points in texts.
-            if (peek() == '\n' || peek() == '\r') {
-              return builder.toString().trim();
-            }
-          }
-        case '\t':
-          if (inParenthesis < 0 && inBrackets < 0) {
-
-            // Do not write a whitespace if:
-            // - we are at the beginning of a new sentence
-            // - the previous character already was a whitespace
-            if (builder.length() > 0
-                && !Character.isWhitespace(builder.charAt(builder.length() - 1))) {
-              builder.append(' ');
-            }
-          }
-          break;
-        case '(':
-          inParenthesis++;
-          break;
-        case '[':
-          inBrackets++;
-          break;
-        case ')':
-          inParenthesis--;
-          break;
-        case ']':
-          inBrackets--;
-          break;
-        case '.':
-        case ':':
-          if (inParenthesis < 0 && inBrackets < 0) {
-            if (builder.length() > 0 && Character.isDigit(builder.charAt(builder.length() - 1))
-                && Character.isDigit(peek())) { // 3.14 or 2:30
-              builder.append(c);
-              break;
-            }
-          }
-        case '?':
-        case '!':
-        case ';':
-          if (inParenthesis < 0 && inBrackets < 0) {
-            builder.append(c);
-            return builder.toString().trim();
-          }
-          break;
-        default:
-          if (inParenthesis < 0 && inBrackets < 0) {
-            if (!Character.isWhitespace(c)) {
-
-              // Append all non-whitespace characters
-              builder.append(c);
-            } else if (builder.length() == 0) {
-
-              // Do not write a whitespace at the beginning of a sentence
-              builder.append(c);
-            } else if (!Character.isWhitespace(builder.charAt(builder.length() - 1))) {
-
-              // Do not write a whitespace if the previous character already was a whitespace
-              builder.append(c);
-            }
-          }
-          break;
-      }
-    }
-    return builder.toString().trim();
-  }
-
-  /**
-   * Instead of iterating on characters or sentences, iterate on paragraphs.
-   *
-   * @return a paragraph.
-   */
-  public String nextParagraph() {
-
-    char prevChar = '\n';
-    StringBuilder builder = new StringBuilder();
-
-    while (hasNext()) {
-
-      char c = next();
-
-      if ((c == '\n' || c == '\r') && (prevChar == '\n' || prevChar == '\r')) {
-        return builder.toString().trim();
-      }
-
-      prevChar = c;
-      builder.append(c);
-    }
-    return builder.toString().trim();
   }
 
   /**
@@ -242,9 +1111,6 @@ final public class StringIterator implements Iterator<Character> {
 
   /**
    * Extracts a substring from the specified range of the current text.
-   *
-   * @param start
-   * @return
    */
   public String extract(int start) {
     return extract(start, text_.length());
@@ -252,10 +1118,6 @@ final public class StringIterator implements Iterator<Character> {
 
   /**
    * Extracts a substring from the specified range of the current text.
-   *
-   * @param start
-   * @param end
-   * @return
    */
   public String extract(int start, int end) {
 
@@ -326,7 +1188,7 @@ final public class StringIterator implements Iterator<Character> {
   public void moveToEndOfLine() {
 
     char c = peek();
-    while (c != '\r' && c != '\n' && !isEndOfText()) {
+    while (c != LF && c != CR && !isEndOfText()) {
       moveAhead();
       c = peek();
     }
@@ -336,7 +1198,7 @@ final public class StringIterator implements Iterator<Character> {
    * Moves the current position to the next character that is a whitespace.
    */
   public void moveToWhitespace() {
-    while (!Character.isWhitespace(peek()) && !isEndOfText()) {
+    while (!isWhitespace(peek()) && !isEndOfText()) {
       moveAhead();
     }
   }
@@ -345,7 +1207,7 @@ final public class StringIterator implements Iterator<Character> {
    * Moves the current position to the next character that is not whitespace.
    */
   public void movePastWhitespace() {
-    while (Character.isWhitespace(peek()) && !isEndOfText()) {
+    while (isWhitespace(peek()) && !isEndOfText()) {
       moveAhead();
     }
   }
@@ -355,7 +1217,6 @@ final public class StringIterator implements Iterator<Character> {
    *
    * @param c Character to find.
    * @param chars Character array to search.
-   * @return
    */
   private boolean isInArray(char c, char[] chars) {
 

--- a/src/cc/mallet/pipe/TokenSequence2TokenInstances.java
+++ b/src/cc/mallet/pipe/TokenSequence2TokenInstances.java
@@ -1,0 +1,64 @@
+package cc.mallet.pipe;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Iterator;
+
+import cc.mallet.types.Instance;
+import cc.mallet.types.LabelSequence;
+import cc.mallet.types.TokenSequence;
+
+
+public class TokenSequence2TokenInstances extends Pipe {
+
+	private class TokenInstanceIterator implements Iterator<Instance>
+	{
+		Iterator<Instance> source;
+		Instance currentInstance = null;
+		TokenSequence currentTokenSequence;
+		int currentIndex;
+		public TokenInstanceIterator (Iterator<Instance> source) {
+			if (source.hasNext()) {
+				currentInstance = source.next();
+				currentTokenSequence = (TokenSequence) currentInstance.getData();
+			}
+			currentIndex = 0;
+		}
+		public Instance next ()	{
+			if (currentIndex >= currentTokenSequence.size()) {
+				currentInstance = source.next();
+				currentTokenSequence = (TokenSequence) currentInstance.getData();
+        currentIndex = 0;
+			}
+			Instance ret = new Instance (currentTokenSequence.get(currentIndex),
+					((LabelSequence)currentInstance.getTarget()).getLabelAtPosition(currentIndex),
+					null, null);
+			currentIndex++;
+			return ret;
+		}
+		public boolean hasNext ()	{
+			return currentInstance != null && (currentIndex < currentTokenSequence.size() || source.hasNext());
+		}
+		public void remove () { throw new IllegalStateException ("This iterator does not support remove().");	}
+	}
+
+	public Iterator<Instance> newIteratorFrom (Iterator<Instance> source) 
+	{
+		return new TokenInstanceIterator (source);
+	}
+	
+	// Serialization 
+	
+	private static final long serialVersionUID = 1;
+	private static final int CURRENT_SERIAL_VERSION = 0;
+	
+	private void writeObject (ObjectOutputStream out) throws IOException {
+		out.writeInt (CURRENT_SERIAL_VERSION);
+	}
+	
+	private void readObject (ObjectInputStream in) throws IOException, ClassNotFoundException {
+		int version = in.readInt ();
+	}
+	
+}

--- a/src/cc/mallet/pipe/tests/TestStringIterator.java
+++ b/src/cc/mallet/pipe/tests/TestStringIterator.java
@@ -11,59 +11,12 @@ package cc.mallet.pipe.tests;
 import java.util.ArrayList;
 import java.util.List;
 
-import cc.mallet.pipe.StringIterator;
+import org.junit.Test;
 
+import cc.mallet.pipe.StringIterator;
 import junit.framework.TestCase;
 
 public class TestStringIterator extends TestCase {
-
-  private static String text1() {
-    return "In our article, we examine network visualizations as a\n"
-        + "means of enhancing the interpretability of probabilistic topic\n"
-        + "models for insight discovery. We focus on what is perhaps\n"
-        + "the most popular and prevalently used topic model: latent\n"
-        + "Dirichlet allocation or LDA (Blei, Ng and Jordan 2003). Topic\n"
-        + "modeling algorithms like LDA discover latent themes (i.e.,\n"
-        + "topics) in document collections and represent documents as a\n"
-        + "combination of these themes. Thus, they are critical tools for\n"
-        + "exploring text data across many domains. It is often the case\n"
-        + "that users must discover the subject matter buried within large\n"
-        + "and unfamiliar document sets (e.g., sensemaking in text data).\n"
-        + "Keyword searches are inadequate here, since even to begin\n"
-        + "searching is unclear. Topic discovery techniques such as LDA\n"
-        + "are a boon to users in such scenarios, because they reveal the\n"
-        + "content in an unsupervised and automated fashion. However,\n"
-        + "obtaining a “big picture” view of the larger trends in a document\n"
-        + "collection from only the raw output of an LDA model can be\n"
-        + "challenging. In our article, we investigate, the use of what we\n"
-        + "refer to as topic similarity networks to address this challenge.\n"
-        + "Topic similarity networks are graphs in which nodes represent\n"
-        + "latent topics in text collections, and links represent similarity\n"
-        + "among topics. We described efficient and effective methods to\n"
-        + "both building and labeling such networks.";
-  }
-
-  private static String text2() {
-    return "Note de R10 rédigée le 25/10/2000\n" + "\n" + "\n"
-        + "Objet : Observation sur l’individu Christian Dumont\n" + "\n"
-        + "Il a été constaté par R10 que Christian Dumont a rencontré les individus suivants :\n"
-        + "\n" + "-\t Nathalie Guerin\n" + "\n" + "-\t Christine Morel\n" + "\n" + "\n"
-        + "Le rendez-vous a eu lieu le 5/8/2012  à 12:32 dans son habitation situé à Paris.\n"
-        + "\n"
-        + "Cette rencontre a duré environ 5 h.D’après  notre source il semblerait que le sujet de la réunion était la préparation d'une recette de cuisine.\n";
-  }
-
-  private static String text3() {
-    return "Compatibility of systems of linear constraints over the set of natural numbers\n\n"
-        + "Criteria of compatibility of a system of linear Diophantine equations, strict "
-        + "inequations,\n"
-        + "and nonstrict inequations are considered. Upper bounds for components of a minimal set\n"
-        + "of solutions and algorithms of construction of minimal generating sets of solutions for "
-        + "all\n"
-        + "types of systems are given. These criteria and the corresponding algorithms for\n"
-        + "constructing a minimal supporting set of solutions can be used in solving all the\n"
-        + "considered types of systems and systems of mixed types.";
-  }
 
   public void testNullStringConstructor() {
 
@@ -121,10 +74,10 @@ public class TestStringIterator extends TestCase {
 
     assertEquals(string, iterator.extract(0));
     assertEquals(string, iterator.extract(0, string.length()));
-    assertEquals("this", iterator.extract(0, 4).toString());
-    assertEquals(" ", iterator.extract(4, 5).toString());
-    assertEquals("\"", iterator.extract(18, 19).toString());
-    assertEquals("https://www.google.com", iterator.extract(19, 41).toString());
+    assertEquals("this", iterator.extract(0, 4));
+    assertEquals(" ", iterator.extract(4, 5));
+    assertEquals("\"", iterator.extract(18, 19));
+    assertEquals("https://www.google.com", iterator.extract(19, 41));
   }
 
   public void testMoveAhead() {
@@ -271,151 +224,240 @@ public class TestStringIterator extends TestCase {
     assertEquals(15, iterator.remaining());
   }
 
-  public void testNextSentence1() {
+  public void testBeginsWithWhitespaces() {
 
-    List<String> sentences = new ArrayList<>();
-    StringIterator iterator = new StringIterator(text1());
+    String textIn = "\n\n\nvéhicule de - de 3,5t";
+    String textOut = "véhicule de - de 3,5t";
 
-    while (iterator.hasNextSentence()) {
+    assertEquals(textOut, StringIterator.clean(textIn));
+  }
 
-      String sentence = iterator.nextSentence();
-      if (sentence != null && !sentence.isEmpty()) {
-        sentences.add(sentence);
-      }
-    }
+  public void testEndsWithWhitespaces() {
 
-    assertEquals(12, sentences.size());
+    String textIn = "véhicule de - de 3,5t\n\n\n";
+    String textOut = "véhicule de - de 3,5t";
+
+    assertEquals(textOut, StringIterator.clean(textIn));
+  }
+
+  public void testNumericBulletPoints() {
+
+    String textIn = "Ma liste:\n1) première entrée ;\n2) dernière entrée.";
+    String textOut = "Ma liste:\n1) première entrée ;\n2) dernière entrée.";
+
+    assertEquals(textOut, StringIterator.clean(textIn));
+  }
+
+  public void testHyphenBulletPoints() {
+
+    String textIn = "Ma liste:\n- première entrée ;\n- dernière entrée.";
+    String textOut = "Ma liste:\n- première entrée ;\n- dernière entrée.";
+
+    assertEquals(textOut, StringIterator.clean(textIn));
+  }
+
+  public void testLinebreakInsideSentence() {
+
+    String textIn = "Ceci est un\nretour à la ligne.";
+    String textOut = "Ceci est un retour à la ligne.";
+
+    assertEquals(textOut, StringIterator.clean(textIn));
+  }
+
+  public void testHyphenInsideSentence() {
+
+    String textIn = "Ceci est un re-\ntour à la ligne.";
+    String textOut = "Ceci est un re- tour à la ligne.";
+
+    assertEquals(textOut, StringIterator.clean(textIn));
+  }
+
+  public void testIdEst() {
+
+    String textIn = "i.e.\ntopics";
+    String textOut = "i.e. topics";
+
+    assertEquals(textOut, StringIterator.clean(textIn));
+  }
+
+  public void testExempliGratia() {
+
+    String textIn = "e.g. topics";
+    String textOut = "e.g. topics";
+
+    assertEquals(textOut, StringIterator.clean(textIn));
+  }
+
+  public void testFormula() {
+
+    String text =
+        "Prime HT de l'année N = (indice N / indice N-1) x somme des primes par véhicule.";
+    List<String> sentences = StringIterator.sentences(text, false);
+
+    assertEquals(text, sentences.get(0));
+  }
+
+  public void testIsLowerCase() {
+
+    assertTrue(StringIterator.isLowerCase("lowercase"));
+    assertFalse(StringIterator.isLowerCase("CamelCase"));
+    assertFalse(StringIterator.isLowerCase("UPPERCASE"));
+
+    assertTrue(StringIterator.isLowerCase(" \n\r lowercase"));
+    assertTrue(StringIterator.isLowerCase("lowercase \n\r "));
+
+    assertFalse(StringIterator.isLowerCase(" \n\r CamelCase"));
+    assertFalse(StringIterator.isLowerCase("CamelCase \n\r "));
+
+    assertFalse(StringIterator.isLowerCase(" \n\r UPPERCASE"));
+    assertFalse(StringIterator.isLowerCase("UPPERCASE \n\r "));
+  }
+
+  public void testIsUpperCase() {
+
+    assertTrue(StringIterator.isUpperCase("UPPERCASE"));
+    assertFalse(StringIterator.isUpperCase("CamelCase"));
+    assertFalse(StringIterator.isUpperCase("lowercase"));
+
+    assertTrue(StringIterator.isUpperCase(" \n\r UPPERCASE"));
+    assertTrue(StringIterator.isUpperCase("UPPERCASE \n\r "));
+
+    assertFalse(StringIterator.isUpperCase(" \n\r CamelCase"));
+    assertFalse(StringIterator.isUpperCase("CamelCase \n\r "));
+
+    assertFalse(StringIterator.isUpperCase(" \n\r lowercase"));
+    assertFalse(StringIterator.isUpperCase("lowercase \n\r "));
+  }
+
+  public void testIsCapitalized() {
+
+    assertTrue(StringIterator.isCapitalized("Capitalized"));
+    assertFalse(StringIterator.isCapitalized("UPPERCASE"));
+    assertFalse(StringIterator.isCapitalized("lowercase"));
+    assertFalse(StringIterator.isCapitalized("CamelCase"));
+
+    assertTrue(StringIterator.isCapitalized(" \n\r Capitalized"));
+    assertTrue(StringIterator.isCapitalized("Capitalized \n\r "));
+
+    assertFalse(StringIterator.isCapitalized(" \n\r UPPERCASE"));
+    assertFalse(StringIterator.isCapitalized("UPPERCASE \n\r "));
+
+    assertFalse(StringIterator.isCapitalized(" \n\r lowercase"));
+    assertFalse(StringIterator.isCapitalized("lowercase \n\r "));
+
+    assertFalse(StringIterator.isCapitalized(" \n\r CamelCase"));
+    assertFalse(StringIterator.isCapitalized("CamelCase \n\r "));
+  }
+
+  public void testIsBlank() {
+
+    assertTrue(StringIterator.isBlank(" \n\r\f\t "));
+    assertFalse(StringIterator.isBlank(" nrft "));
+  }
+
+  public void testTrimLeft() {
+
+    assertEquals("Capitalized", StringIterator.trimLeft(" \n Capitalized"));
+    assertEquals("Capitalized", StringIterator.trimLeft(" \r Capitalized"));
+
+    assertEquals("Capitalized \n ", StringIterator.trimLeft("Capitalized \n "));
+    assertEquals("Capitalized \r ", StringIterator.trimLeft("Capitalized \r "));
+  }
+
+  public void testTrimRight() {
+
+    assertEquals(" \n Capitalized", StringIterator.trimRight(" \n Capitalized"));
+    assertEquals(" \r Capitalized", StringIterator.trimRight(" \r Capitalized"));
+
+    assertEquals("Capitalized", StringIterator.trimRight("Capitalized \n "));
+    assertEquals("Capitalized", StringIterator.trimRight("Capitalized \r "));
+  }
+
+  public void testUpperCaseSectionHeader() {
+
+    List<String> strings = new ArrayList<>();
+    strings.add("CONDUITE EN ETAT D'EBRIETE OU SOUS L'EMPRISE DE STUPEFIANTS");
+    strings.add("Les garanties du contrat, y compris de dommages, restent acquises à l'assuré");
+    strings.add("lorsqu'un sinistre intervient alors que le conducteur,");
+    strings.add("employé de l'assuré, conduit, à l'insu de l'assuré,");
+    strings.add("en état d'ébriété ou sous l'emprise de stupéfiants.");
+
+    String text = join(strings);
+    List<String> sentences = StringIterator.sentences(text, false);
+
+    assertEquals("CONDUITE EN ETAT D'EBRIETE OU SOUS L'EMPRISE DE STUPEFIANTS", sentences.get(0));
     assertEquals(
-        "In our article, we examine network visualizations as a means of enhancing the interpretability of probabilistic topic models for insight discovery.",
-        sentences.get(0));
-    assertEquals("We focus on what is perhaps the most popular and prevalently used topic model:",
+        "Les garanties du contrat, y compris de dommages, restent acquises à l'assuré lorsqu'un sinistre intervient alors que le conducteur, employé de l'assuré, conduit, à l'insu de l'assuré, en état d'ébriété ou sous l'emprise de stupéfiants.",
         sentences.get(1));
-    assertEquals("latent Dirichlet allocation or LDA .", sentences.get(2));
-    assertEquals(
-        "Topic modeling algorithms like LDA discover latent themes in document collections and represent documents as a combination of these themes.",
-        sentences.get(3));
-    assertEquals("Thus, they are critical tools for exploring text data across many domains.",
-        sentences.get(4));
-    assertEquals(
-        "It is often the case that users must discover the subject matter buried within large and unfamiliar document sets .",
-        sentences.get(5));
-    assertEquals("Keyword searches are inadequate here, since even to begin searching is unclear.",
-        sentences.get(6));
-    assertEquals(
-        "Topic discovery techniques such as LDA are a boon to users in such scenarios, because they reveal the content in an unsupervised and automated fashion.",
-        sentences.get(7));
-    assertEquals(
-        "However, obtaining a “big picture” view of the larger trends in a document collection from only the raw output of an LDA model can be challenging.",
-        sentences.get(8));
-    assertEquals(
-        "In our article, we investigate, the use of what we refer to as topic similarity networks to address this challenge.",
-        sentences.get(9));
-    assertEquals(
-        "Topic similarity networks are graphs in which nodes represent latent topics in text collections, and links represent similarity among topics.",
-        sentences.get(10));
-    assertEquals(
-        "We described efficient and effective methods to both building and labeling such networks.",
-        sentences.get(11));
   }
 
-  public void testNextSentence2() {
+  public void testSimpleText() {
 
-    List<String> sentences = new ArrayList<>();
-    StringIterator iterator = new StringIterator(text2());
+    List<String> strings = new ArrayList<>();
+    strings.add("Note de R10 rédigée le 25/10/2000");
+    strings.add("Objet : Observation sur l'individu Christian Dumont");
+    strings
+        .add("Il a été constaté par R10 que Christian Dumont a rencontré les individus suivants :");
+    strings.add("- Nathalie Guerin");
+    strings.add("- Christine Morel");
+    strings.add(
+        "Le rendez-vous a eu lieu le 5/8/2012 à 12:32 dans son habitation situé à Paris.\nCette rencontre a duré environ 5 h.\nD'après notre source il semblerait que le sujet de la réunion était la préparation d'une recette de cuisine.");
 
-    while (iterator.hasNextSentence()) {
+    String text = join(strings);
+    List<String> sentences = StringIterator.sentences(text, false);
 
-      String sentence = iterator.nextSentence();
-      if (sentence != null && !sentence.isEmpty()) {
-        sentences.add(sentence);
-      }
-    }
-
-    assertEquals(9, sentences.size());
     assertEquals("Note de R10 rédigée le 25/10/2000", sentences.get(0));
-    assertEquals("Objet :", sentences.get(1));
-    assertEquals("Observation sur l’individu Christian Dumont", sentences.get(2));
+    assertEquals("Objet : Observation sur l'individu Christian Dumont", sentences.get(1));
     assertEquals(
         "Il a été constaté par R10 que Christian Dumont a rencontré les individus suivants :",
-        sentences.get(3));
-    assertEquals("- Nathalie Guerin", sentences.get(4));
-    assertEquals("- Christine Morel", sentences.get(5));
+        sentences.get(2));
+    assertEquals("- Nathalie Guerin", sentences.get(3));
+    assertEquals("- Christine Morel", sentences.get(4));
     assertEquals("Le rendez-vous a eu lieu le 5/8/2012 à 12:32 dans son habitation situé à Paris.",
-        sentences.get(6));
-    assertEquals("Cette rencontre a duré environ 5 h.", sentences.get(7));
+        sentences.get(5));
+    assertEquals("Cette rencontre a duré environ 5 h.", sentences.get(6));
     assertEquals(
-        "D’après notre source il semblerait que le sujet de la réunion était la préparation d'une recette de cuisine.",
-        sentences.get(8));
+        "D'après notre source il semblerait que le sujet de la réunion était la préparation d'une recette de cuisine.",
+        sentences.get(7));
   }
 
-  public void testNextParagraph1() {
+  @Test
+  public void testHeader() {
 
-    List<String> paragraphs = new ArrayList<>();
-    StringIterator iterator = new StringIterator(text1());
+    List<String> strings = new ArrayList<>();
+    strings.add("1. Conduite en état d'ébriété ou sous l'emprise de stupéfiants");
+    strings.add("Les garanties du contrat, y compris de dommages, restent acquises à l'assuré");
+    strings.add("lorsqu'un sinistre intervient alors que le conducteur,");
+    strings.add("employé de l'assuré, conduit, à l'insu de l'assuré,");
+    strings.add("en état d'ébriété ou sous l'emprise de stupéfiants.");
 
-    while (iterator.hasNextSentence()) {
+    String text = join(strings);
+    List<String> sentences = StringIterator.sentences(text, false);
 
-      String sentence = iterator.nextParagraph();
-      if (sentence != null && !sentence.isEmpty()) {
-        paragraphs.add(sentence);
-      }
-    }
-
-    assertEquals(1, paragraphs.size());
-    assertEquals(text1(), paragraphs.get(0));
+    assertEquals("1. Conduite en état d'ébriété ou sous l'emprise de stupéfiants",
+        sentences.get(0));
+    assertEquals(
+        "Les garanties du contrat, y compris de dommages, restent acquises à l'assuré lorsqu'un sinistre intervient alors que le conducteur, employé de l'assuré, conduit, à l'insu de l'assuré, en état d'ébriété ou sous l'emprise de stupéfiants.",
+        sentences.get(1));
   }
 
-  public void testNextParagraph2() {
-
-    List<String> paragraphs = new ArrayList<>();
-    StringIterator iterator = new StringIterator(text2());
-
-    while (iterator.hasNextSentence()) {
-
-      String sentence = iterator.nextParagraph();
-      if (sentence != null && !sentence.isEmpty()) {
-        paragraphs.add(sentence);
+  /**
+   * Join a list of strings. Similar to Guava's
+   *
+   * <pre>
+   * Joiner.on('\n').join(strings)
+   * </pre>
+   *
+   * @return a string.
+   */
+  private String join(List<String> strings) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < strings.size(); i++) {
+      if (i > 0) {
+        builder.append('\n');
       }
+      builder.append(strings.get(i));
     }
-
-    assertEquals(7, paragraphs.size());
-    assertEquals("Note de R10 rédigée le 25/10/2000", paragraphs.get(0));
-    assertEquals("Objet : Observation sur l’individu Christian Dumont", paragraphs.get(1));
-    assertEquals(
-        "Il a été constaté par R10 que Christian Dumont a rencontré les individus suivants :",
-        paragraphs.get(2));
-    assertEquals("-\t Nathalie Guerin", paragraphs.get(3));
-    assertEquals("-\t Christine Morel", paragraphs.get(4));
-    assertEquals("Le rendez-vous a eu lieu le 5/8/2012  à 12:32 dans son habitation situé à Paris.",
-        paragraphs.get(5));
-    assertEquals(
-        "Cette rencontre a duré environ 5 h.D’après  notre source il semblerait que le sujet de la réunion était la préparation d'une recette de cuisine.",
-        paragraphs.get(6));
-  }
-
-  public void testNextParagraph3() {
-
-    List<String> paragraphs = new ArrayList<>();
-    StringIterator iterator = new StringIterator(text3());
-
-    while (iterator.hasNextSentence()) {
-
-      String sentence = iterator.nextParagraph();
-      if (sentence != null && !sentence.isEmpty()) {
-        paragraphs.add(sentence);
-      }
-    }
-
-    assertEquals(2, paragraphs.size());
-    assertEquals("Compatibility of systems of linear constraints over the set of natural numbers",
-        paragraphs.get(0));
-    assertEquals("Criteria of compatibility of a system of linear Diophantine equations, strict "
-        + "inequations,\n"
-        + "and nonstrict inequations are considered. Upper bounds for components of a minimal set\n"
-        + "of solutions and algorithms of construction of minimal generating sets of solutions for "
-        + "all\n"
-        + "types of systems are given. These criteria and the corresponding algorithms for\n"
-        + "constructing a minimal supporting set of solutions can be used in solving all the\n"
-        + "considered types of systems and systems of mixed types.", paragraphs.get(1));
+    return builder.toString();
   }
 }

--- a/src/cc/mallet/topics/TopicalNGrams.java
+++ b/src/cc/mallet/topics/TopicalNGrams.java
@@ -8,10 +8,20 @@
 package cc.mallet.topics;
 
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
 import java.util.Arrays;
-import java.io.*;
 
-import cc.mallet.types.*;
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.AugmentableFeatureVector;
+import cc.mallet.types.FeatureSequence;
+import cc.mallet.types.FeatureSequenceWithBigrams;
+import cc.mallet.types.InstanceList;
 import cc.mallet.util.Randoms;
 
 /**
@@ -407,7 +417,7 @@ public class TopicalNGrams {
   {
     pw.println ("#doc source topic proportions");
     int docLen;
-    double topicDist[] = new double[topics.length];
+    double topicDist[] = new double[numTopics];
     for (int di = 0; di < topics.length; di++) {
       pw.print (di); pw.print (' ');
       pw.print (ilist.get(di).getSource().toString()); pw.print (' ');


### PR DESCRIPTION
Improvements on StringIterator :
- Add better tests (easier to read) ;
- Classify char code 160 as whitespace ;
- Split test cleaning and sentence parsing. It is now working quite well to format texts extracted from PDF files with [Apache Tika](https://tika.apache.org/).

Closes [Issue 104](https://github.com/mimno/Mallet/issues/104) : `TokenInstanceIterator` does not iterate on more than one `Instance`.

Closes [Issue 126](https://github.com/mimno/Mallet/issues/126) : `printDocumentTopics()` throws an `IndexOutOfBoundsException` if the number of topics is not the same as the number of documents.

Be aware that due to compilation issues on Windows 10 I had to remove the symlink from `lib/errorprone.jar` in the `build.xml` file ([commit ec265c3](https://github.com/mimno/Mallet/commit/761d4e006bbd32b74d4800347521327cb2964d2d)). Tell me if I need to rollback it for the pull-request.

