### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,13 @@
       <artifactId>jdom</artifactId>
       <version>1.1</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.carrotsearch/hppc -->
+<dependency>
+    <groupId>com.carrotsearch</groupId>
+    <artifactId>hppc</artifactId>
+    <version>0.8.1</version>
+</dependency>
+
   </dependencies>
   <distributionManagement>
     <snapshotRepository>


### PR DESCRIPTION
adding carrotsearch.hppc dependency into pom.xml to dix build failures in jitpack.io build of snapshots - 

see build log with failure:.
[https://jitpack.io/com/github/mimno/Mallet/b2fd74a3ba/build.log]

N.B. I picked up the most recent version (0.8.1) but note that the ant build uses 0.7.1 - so far no issues though.