### PR TITLE
Iterate over input data, don't load into memory

### DIFF
--- a/src/cc/mallet/classify/tui/Csv2Vectors.java
+++ b/src/cc/mallet/classify/tui/Csv2Vectors.java
@@ -317,7 +317,12 @@ public class Csv2Vectors {
 			oos = new ObjectOutputStream(System.out);
 		}
 		else {
-			Files.delete(outputFile.value.toPath());
+			try {
+				Files.delete(outputFile.value.toPath());
+			} catch (java.nio.file.NoSuchFileException e){
+				// file doesn't exist
+
+			}
 			oos = new ObjectOutputStream(new FileOutputStream(outputFile.value, true));
 		}
 		CsvIterator csvIterator = new CsvIterator (fileReader, Pattern.compile(lineRegex.value),

--- a/src/cc/mallet/classify/tui/Csv2Vectors.java
+++ b/src/cc/mallet/classify/tui/Csv2Vectors.java
@@ -328,11 +328,14 @@ public class Csv2Vectors {
 		CsvIterator csvIterator = new CsvIterator (fileReader, Pattern.compile(lineRegex.value),
 												   dataOption.value, labelOption.value, nameOption.value);
 		InstanceList instances = new InstanceList (instancePipe);
+		Integer totalInstances =  0;
 		while (csvIterator.hasNext())  {
 
 			instances.addThruPipe(csvIterator.next());
 			if (instances.size() == 10000) {
 				oos.writeUnshared(instances);
+				totalInstances +=  instances.size();
+				logger.info(String.format("wrote %d instances to output file", totalInstances));
 				instances = new InstanceList(instancePipe);
 				oos.reset();
 			}
@@ -342,7 +345,8 @@ public class Csv2Vectors {
 
 		if (instances.size() > 0)
 			oos.writeUnshared(instances);
-
+		totalInstances += instances.size();
+		logger.info(String.format("wrote %d instances to output file", totalInstances));
 		oos.close();
 		fileReader.close();
 

--- a/src/cc/mallet/classify/tui/Csv2Vectors.java
+++ b/src/cc/mallet/classify/tui/Csv2Vectors.java
@@ -334,6 +334,7 @@ public class Csv2Vectors {
 			if (instances.size() == 10000) {
 				oos.writeUnshared(instances);
 				instances = new InstanceList(instancePipe);
+				oos.reset();
 			}
 
 		}
@@ -343,6 +344,7 @@ public class Csv2Vectors {
 			oos.writeUnshared(instances);
 
 		oos.close();
+		fileReader.close();
 
 
 		// If we are reusing a pipe from an instance list 

--- a/src/cc/mallet/classify/tui/Csv2Vectors.java
+++ b/src/cc/mallet/classify/tui/Csv2Vectors.java
@@ -331,8 +331,8 @@ public class Csv2Vectors {
 		while (csvIterator.hasNext())  {
 
 			instances.addThruPipe(csvIterator.next());
-			if (instances.size() == 1000000) {
-				oos.writeObject(instances);
+			if (instances.size() == 10000) {
+				oos.writeUnshared(instances);
 				instances = new InstanceList(instancePipe);
 			}
 
@@ -340,7 +340,7 @@ public class Csv2Vectors {
 
 
 		if (instances.size() > 0)
-			oos.writeObject(instances);
+			oos.writeUnshared(instances);
 
 		oos.close();
 


### PR DESCRIPTION

The current implementation loads the entire input file into memory, leading to memory growth and exhaustion for large data sets.  This is a POC for out of core data sets. 

**Notes:**

- not a Java dev, this works but can likely be improved. PR is for visibility of the issue, which I spent a week or more on and off with. 

- does not solve the issue of the LDA model training trying to load all the data into memory, if possible we should find a way to make that iterable as well.
