### PR TITLE
Reduce array writes when re-sorting.

### DIFF
--- a/src/main/java/cc/mallet/topics/MergeCallable.java
+++ b/src/main/java/cc/mallet/topics/MergeCallable.java
@@ -77,19 +77,17 @@ public class MergeCallable implements Callable<String> {
                     }
                     currentCount = targetCounts[targetIndex] >> topicBits;
                     
-                    targetCounts[targetIndex] =
+                    int targetCount =
                         ((currentCount + count) << topicBits) + topic;
                     
                     // Now ensure that the array is still sorted by 
                     //  bubbling this value up.
                     while (targetIndex > 0 &&
-                           targetCounts[targetIndex] > targetCounts[targetIndex - 1]) {
-                        int temp = targetCounts[targetIndex];
+                           targetCount > targetCounts[targetIndex - 1]) {
                         targetCounts[targetIndex] = targetCounts[targetIndex - 1];
-                        targetCounts[targetIndex - 1] = temp;
-                        
                         targetIndex--;
                     }
+                    targetCounts[targetIndex] = targetCount;
                     
                     sourceIndex++;
                 }

--- a/src/main/java/cc/mallet/topics/ParallelTopicModel.java
+++ b/src/main/java/cc/mallet/topics/ParallelTopicModel.java
@@ -435,17 +435,17 @@ public class ParallelTopicModel implements Serializable {
                         (1 << topicBits) + topic;
                 }
                 else {
-                    int currentTypeTopicCount =
+                    int updatedCount =
                         ((currentValue + 1) << topicBits) + topic;
                     
                     // Now ensure that the array is still sorted by 
                     //  bubbling this value up.
                     while (index > 0 &&
-                           currentTypeTopicCount > currentTypeTopicCounts[index - 1]) {
+                           updatedCount > currentTypeTopicCounts[index - 1]) {
                         currentTypeTopicCounts[index] = currentTypeTopicCounts[index - 1];
                         index--;
                     }
-                    currentTypeTopicCounts[index] = currentTypeTopicCount;
+                    currentTypeTopicCounts[index] = updatedCount;
                 }
             }
         }

--- a/src/main/java/cc/mallet/topics/ParallelTopicModel.java
+++ b/src/main/java/cc/mallet/topics/ParallelTopicModel.java
@@ -435,19 +435,17 @@ public class ParallelTopicModel implements Serializable {
                         (1 << topicBits) + topic;
                 }
                 else {
-                    currentTypeTopicCounts[index] =
+                    int currentTypeTopicCount =
                         ((currentValue + 1) << topicBits) + topic;
                     
                     // Now ensure that the array is still sorted by 
                     //  bubbling this value up.
                     while (index > 0 &&
-                           currentTypeTopicCounts[index] > currentTypeTopicCounts[index - 1]) {
-                        int temp = currentTypeTopicCounts[index];
+                           currentTypeTopicCount > currentTypeTopicCounts[index - 1]) {
                         currentTypeTopicCounts[index] = currentTypeTopicCounts[index - 1];
-                        currentTypeTopicCounts[index - 1] = temp;
-                        
                         index--;
                     }
+                    currentTypeTopicCounts[index] = currentTypeTopicCount;
                 }
             }
         }

--- a/src/main/java/cc/mallet/topics/WorkerCallable.java
+++ b/src/main/java/cc/mallet/topics/WorkerCallable.java
@@ -225,16 +225,16 @@ public class WorkerCallable implements Callable<Integer> {
                     currentTypeTopicCounts[index] = (1 << topicBits) + topic;
                 }
                 else {
-                    int currentTypeTopicCount =
+                    int updatedCount =
                         ((currentValue + 1) << topicBits) + topic;
                     
                     // Now ensure that the array is still sorted by 
                     //  bubbling this value up.
-                    while (index > 0 && currentTypeTopicCount > currentTypeTopicCounts[index - 1]) {
+                    while (index > 0 && updatedCount > currentTypeTopicCounts[index - 1]) {
                         currentTypeTopicCounts[index] = currentTypeTopicCounts[index - 1];
                         index--;
                     }
-                    currentTypeTopicCounts[index] = currentTypeTopicCount;
+                    currentTypeTopicCounts[index] = updatedCount;
                 }
             }
         }
@@ -448,12 +448,12 @@ public class WorkerCallable implements Callable<Integer> {
                     //  look at this cell in the array again.
 
                     currentValue --;
-                    int currentTypeTopicCount;
+                    int updatedCount;
                     if (currentValue == 0) {
-                        currentTypeTopicCount = 0;
+                        updatedCount = 0;
                     }
                     else {
-                        currentTypeTopicCount =
+                        updatedCount =
                             (currentValue << topicBits) + oldTopic;
                     }
                     
@@ -462,11 +462,11 @@ public class WorkerCallable implements Callable<Integer> {
                     @Var
                     int subIndex = index;
                     while (subIndex < currentTypeTopicCounts.length - 1 && 
-                           currentTypeTopicCount < currentTypeTopicCounts[subIndex + 1]) {
+                           updatedCount < currentTypeTopicCounts[subIndex + 1]) {
                         currentTypeTopicCounts[subIndex] = currentTypeTopicCounts[subIndex + 1];
                         subIndex++;
                     }
-                    currentTypeTopicCounts[subIndex] = currentTypeTopicCount;
+                    currentTypeTopicCounts[subIndex] = updatedCount;
 
                     alreadyDecremented = true;
                 }
@@ -499,16 +499,16 @@ public class WorkerCallable implements Callable<Integer> {
                 newTopic = currentTypeTopicCounts[i] & topicMask;
                 currentValue = currentTypeTopicCounts[i] >> topicBits;
                 
-                int currentTypeTopicCount = ((currentValue + 1) << topicBits) + newTopic;
+                int updatedCount = ((currentValue + 1) << topicBits) + newTopic;
 
                 // Bubble the new value up, if necessary
                 
                 while (i > 0 &&
-                       currentTypeTopicCount > currentTypeTopicCounts[i - 1]) {
+                       updatedCount > currentTypeTopicCounts[i - 1]) {
                     currentTypeTopicCounts[i] = currentTypeTopicCounts[i - 1];
                     i--;
                 }
-                currentTypeTopicCounts[i] = currentTypeTopicCount;
+                currentTypeTopicCounts[i] = updatedCount;
 
             }
             else {
@@ -581,15 +581,15 @@ public class WorkerCallable implements Callable<Integer> {
                 }
                 else {
                     currentValue = currentTypeTopicCounts[index] >> topicBits;
-                    int currentTypeTopicCount = ((currentValue + 1) << topicBits) + newTopic;
+                    int updatedCount = ((currentValue + 1) << topicBits) + newTopic;
 
                     // Bubble the increased value left, if necessary
                     while (index > 0 &&
-                           currentTypeTopicCount > currentTypeTopicCounts[index - 1]) {
+                           updatedCount > currentTypeTopicCounts[index - 1]) {
                         currentTypeTopicCounts[index] = currentTypeTopicCounts[index - 1];
                         index--;
                     }
-                    currentTypeTopicCounts[index] = currentTypeTopicCount;
+                    currentTypeTopicCounts[index] = updatedCount;
                 }
 
             }

--- a/src/main/java/cc/mallet/topics/WorkerCallable.java
+++ b/src/main/java/cc/mallet/topics/WorkerCallable.java
@@ -225,18 +225,16 @@ public class WorkerCallable implements Callable<Integer> {
                     currentTypeTopicCounts[index] = (1 << topicBits) + topic;
                 }
                 else {
-                    currentTypeTopicCounts[index] =
+                    int currentTypeTopicCount =
                         ((currentValue + 1) << topicBits) + topic;
                     
                     // Now ensure that the array is still sorted by 
                     //  bubbling this value up.
-                    while (index > 0 && currentTypeTopicCounts[index] > currentTypeTopicCounts[index - 1]) {
-                        int temp = currentTypeTopicCounts[index];
+                    while (index > 0 && currentTypeTopicCount > currentTypeTopicCounts[index - 1]) {
                         currentTypeTopicCounts[index] = currentTypeTopicCounts[index - 1];
-                        currentTypeTopicCounts[index - 1] = temp;
-                        
                         index--;
                     }
+                    currentTypeTopicCounts[index] = currentTypeTopicCount;
                 }
             }
         }
@@ -450,11 +448,12 @@ public class WorkerCallable implements Callable<Integer> {
                     //  look at this cell in the array again.
 
                     currentValue --;
+                    int currentTypeTopicCount;
                     if (currentValue == 0) {
-                        currentTypeTopicCounts[index] = 0;
+                        currentTypeTopicCount = 0;
                     }
                     else {
-                        currentTypeTopicCounts[index] =
+                        currentTypeTopicCount =
                             (currentValue << topicBits) + oldTopic;
                     }
                     
@@ -463,13 +462,11 @@ public class WorkerCallable implements Callable<Integer> {
                     @Var
                     int subIndex = index;
                     while (subIndex < currentTypeTopicCounts.length - 1 && 
-                           currentTypeTopicCounts[subIndex] < currentTypeTopicCounts[subIndex + 1]) {
-                        int temp = currentTypeTopicCounts[subIndex];
+                           currentTypeTopicCount < currentTypeTopicCounts[subIndex + 1]) {
                         currentTypeTopicCounts[subIndex] = currentTypeTopicCounts[subIndex + 1];
-                        currentTypeTopicCounts[subIndex + 1] = temp;
-                        
                         subIndex++;
                     }
+                    currentTypeTopicCounts[subIndex] = currentTypeTopicCount;
 
                     alreadyDecremented = true;
                 }
@@ -502,18 +499,16 @@ public class WorkerCallable implements Callable<Integer> {
                 newTopic = currentTypeTopicCounts[i] & topicMask;
                 currentValue = currentTypeTopicCounts[i] >> topicBits;
                 
-                currentTypeTopicCounts[i] = ((currentValue + 1) << topicBits) + newTopic;
+                int currentTypeTopicCount = ((currentValue + 1) << topicBits) + newTopic;
 
                 // Bubble the new value up, if necessary
                 
                 while (i > 0 &&
-                       currentTypeTopicCounts[i] > currentTypeTopicCounts[i - 1]) {
-                    int temp = currentTypeTopicCounts[i];
+                       currentTypeTopicCount > currentTypeTopicCounts[i - 1]) {
                     currentTypeTopicCounts[i] = currentTypeTopicCounts[i - 1];
-                    currentTypeTopicCounts[i - 1] = temp;
-
                     i--;
                 }
+                currentTypeTopicCounts[i] = currentTypeTopicCount;
 
             }
             else {
@@ -586,17 +581,15 @@ public class WorkerCallable implements Callable<Integer> {
                 }
                 else {
                     currentValue = currentTypeTopicCounts[index] >> topicBits;
-                    currentTypeTopicCounts[index] = ((currentValue + 1) << topicBits) + newTopic;
+                    int currentTypeTopicCount = ((currentValue + 1) << topicBits) + newTopic;
 
                     // Bubble the increased value left, if necessary
                     while (index > 0 &&
-                           currentTypeTopicCounts[index] > currentTypeTopicCounts[index - 1]) {
-                        int temp = currentTypeTopicCounts[index];
+                           currentTypeTopicCount > currentTypeTopicCounts[index - 1]) {
                         currentTypeTopicCounts[index] = currentTypeTopicCounts[index - 1];
-                        currentTypeTopicCounts[index - 1] = temp;
-
                         index--;
                     }
+                    currentTypeTopicCounts[index] = currentTypeTopicCount;
                 }
 
             }


### PR DESCRIPTION
The reordering was done with a swap-based bubble: each step performed a three-assignment swap (temp = a[i]; a[i] = a[i-1]; a[i-1] = temp), writing the moving value into and back out of every slot it passes through.

In the updated code the moved value is only written in the array once the correct position is known and other values in the array that need to be shifted are only overwritten once.

The while loop also uses a local variable instead of retrieving the value from the array everything, possibly eliminating a bound check.