### PR TITLE
Bound the smoothing-only sampling walk; recompute its mass per document

### DIFF
--- a/src/main/java/cc/mallet/topics/TopicInferencer.java
+++ b/src/main/java/cc/mallet/topics/TopicInferencer.java
@@ -302,6 +302,14 @@ public class TopicInferencer implements Serializable {
                                                        "\t" + cachedCoefficients[currentTopic]);
                                     index++;
                                 }
+
+                                // smoothingOnlyMass (used above to draw sample) and this walk are
+                                //  computed by different floating-point paths, so residual
+                                //  rounding error can leave sample > 0.0 past the last topic.
+                                //  The diagnostic above already fired; stop here instead of
+                                //  falling through to the out-of-bounds alpha[numTopics] read.
+                                newTopic = numTopics - 1;
+                                break;
                             }
 
                             sample -= alpha[newTopic] /

--- a/src/main/java/cc/mallet/topics/WorkerCallable.java
+++ b/src/main/java/cc/mallet/topics/WorkerCallable.java
@@ -350,7 +350,20 @@ public class WorkerCallable implements Callable<Integer> {
         @Var
         int changed = 0;
 
-        //    Iterate over the positions (words) in the document 
+        // Recompute the smoothing-only bucket exactly, once per document. It is otherwise
+        //  maintained only by the paired +=/-= updates below as tokens are resampled, and
+        //  floating-point drift in that running total compounds over a long run -- previously
+        //  it was recomputed exactly only once per call() (i.e. once per worker per iteration),
+        //  so drift could accumulate across every token of every document a worker processes
+        //  in an iteration. Recomputing here is O(numTopics), negligible next to the
+        //  O(numTopics * docLength) sampling work already done per document, and bounds the
+        //  drift to at most one document's worth.
+        smoothingOnlyMass = 0.0;
+        for (int topic = 0; topic < numTopics; topic++) {
+            smoothingOnlyMass += alpha[topic] * beta / (tokensPerTopic[topic] + betaSum);
+        }
+
+        //    Iterate over the positions (words) in the document
         for (int position = 0; position < docLength; position++) {
             type = tokenSequence.getIndexAtPosition(position);
             oldTopic = oneDocTopics[position];
@@ -543,12 +556,18 @@ public class WorkerCallable implements Callable<Integer> {
                     sample -= alpha[newTopic] /
                         (tokensPerTopic[newTopic] + betaSum);
 
-                    while (sample > 0.0) {
+                    // Bound the walk to a valid topic index. In exact arithmetic sample would
+                    //  always be consumed before newTopic reaches numTopics, but
+                    //  smoothingOnlyMass (used above to draw sample) and this per-topic walk
+                    //  are computed by different floating-point paths, so residual rounding
+                    //  error can otherwise leave sample > 0.0 past the last topic and read
+                    //  alpha[numTopics] out of bounds.
+                    while (sample > 0.0 && newTopic < numTopics - 1) {
                         newTopic++;
-                        sample -= alpha[newTopic] / 
+                        sample -= alpha[newTopic] /
                             (tokensPerTopic[newTopic] + betaSum);
                     }
-                    
+
                 }
 
                 // Move to the position for the new topic,

--- a/src/test/java/cc/mallet/topics/TestTopicInferencer.java
+++ b/src/test/java/cc/mallet/topics/TestTopicInferencer.java
@@ -1,0 +1,80 @@
+package cc.mallet.topics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.FeatureSequence;
+import cc.mallet.types.Instance;
+import cc.mallet.util.Randoms;
+
+/**
+ * Regression test for https://github.com/mimno/Mallet/issues/219, correctness finding #6:
+ * the smoothing-only branch of the sampler walks topics with no bound, so if the
+ * (independently-computed) smoothingOnlyMass used to draw a sample is ever inconsistent with
+ * the per-topic values used in the walk -- for example residual floating-point drift -- the
+ * walk could run past the last topic and throw ArrayIndexOutOfBoundsException reading
+ * alpha[numTopics]. TopicInferencer#getSampledDistribution now clamps the walk instead.
+ */
+public class TestTopicInferencer {
+
+    private static final int NUM_TOPICS = 3;
+
+    // Forces every draw to land deep in the (here, deliberately inflated) smoothing-only
+    // bucket, so the test doesn't depend on a particular seed happening to produce a small
+    // enough value.
+    private static final class FixedUniformRandoms extends Randoms {
+        FixedUniformRandoms(int seed) { super(seed); }
+
+        @Override
+        public synchronized double nextUniform() { return 0.9; }
+    }
+
+    @Test
+    public void smoothingOnlyWalkIsClampedInsteadOfReadingPastTheLastTopic() {
+        double[] alpha = { 1.0, 1.0, 1.0 };
+        double beta = 0.01;
+        double betaSum = 0.01;
+
+        // A single word type, with counts spread across all three topics, encoded as
+        // (count << topicBits) + topic, sorted descending by count and terminated by 0.
+        int[][] typeTopicCounts = new int[][] {
+            { (5 << 2) + 0, (3 << 2) + 1, (1 << 2) + 2, 0 }
+        };
+        int[] tokensPerTopic = { 5, 3, 1 };
+
+        Alphabet alphabet = new Alphabet();
+        alphabet.lookupIndex("w", true);
+        alphabet.stopGrowth();
+
+        FeatureSequence tokens = new FeatureSequence(alphabet, new int[] { 0, 0, 0 });
+        Instance instance = new Instance(tokens, null, "test", null);
+
+        TopicInferencer inferencer =
+            new TopicInferencer(typeTopicCounts, tokensPerTopic, alphabet, alpha, beta, betaSum);
+        inferencer.random = new FixedUniformRandoms(3);
+
+        // Simulate the kind of inconsistency the bug report describes: a smoothingOnlyMass
+        // wildly larger than the exact per-topic sum it is supposed to represent. Before this
+        // fix, this -- combined with a uniform draw skewed toward the (now huge) smoothing-only
+        // bucket -- read alpha[numTopics] out of bounds.
+        inferencer.smoothingOnlyMass = 1_000_000.0;
+
+        double[] distribution = inferencer.getSampledDistribution(instance, 5, 1, 0);
+
+        assertNotNull(distribution);
+        assertEquals(NUM_TOPICS, distribution.length);
+
+        double sum = 0.0;
+        for (double p : distribution) {
+            assertFalse("distribution entry should be finite", Double.isNaN(p) || Double.isInfinite(p));
+            assertTrue("distribution entry should be non-negative", p >= 0.0);
+            sum += p;
+        }
+        assertEquals(1.0, sum, 1e-9);
+    }
+}

--- a/src/test/java/cc/mallet/topics/TestWorkerCallable.java
+++ b/src/test/java/cc/mallet/topics/TestWorkerCallable.java
@@ -1,0 +1,102 @@
+package cc.mallet.topics;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import cc.mallet.pipe.CharSequence2TokenSequence;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.pipe.SerialPipes;
+import cc.mallet.pipe.TokenSequence2FeatureSequence;
+import cc.mallet.pipe.TokenSequenceLowercase;
+import cc.mallet.pipe.iterator.StringArrayIterator;
+import cc.mallet.types.FeatureSequence;
+import cc.mallet.types.InstanceList;
+import cc.mallet.util.Randoms;
+
+/**
+ * Regression test for https://github.com/mimno/Mallet/issues/219, correctness finding #6:
+ * smoothingOnlyMass was otherwise maintained only by incremental +=/-= updates as tokens are
+ * resampled, so floating-point drift in that running total compounds over a long run.
+ * WorkerCallable#sampleTopicsForOneDoc now recomputes it exactly at the start of every
+ * document instead of relying on the once-per-call() (once per worker per training
+ * iteration) initialization, so an arbitrarily wrong value can survive for at most one
+ * document.
+ */
+public class TestWorkerCallable {
+
+    private static final String[] DOCUMENTS = new String[] {
+        "cat dog cat bird dog cat fish bird cat dog",
+        "soup pasta bread soup cheese pasta bread soup cheese",
+        "guitar drum piano guitar violin drum piano guitar",
+        "dog cat fish dog bird cat dog fish bird cat",
+    };
+
+    // Forces every draw to land deep in whichever bucket dominates the total, so the test
+    // doesn't depend on a particular seed happening to produce a small enough value.
+    private static final class FixedUniformRandoms extends Randoms {
+        FixedUniformRandoms(int seed) { super(seed); }
+
+        @Override
+        public synchronized double nextUniform() { return 0.9; }
+    }
+
+    private static ParallelTopicModel trainSmallModel() throws Exception {
+        ArrayList<Pipe> pipes = new ArrayList<Pipe>();
+        pipes.add(new CharSequence2TokenSequence());
+        pipes.add(new TokenSequenceLowercase());
+        pipes.add(new TokenSequence2FeatureSequence());
+
+        InstanceList instances = new InstanceList(new SerialPipes(pipes));
+        instances.addThruPipe(new StringArrayIterator(DOCUMENTS));
+
+        ParallelTopicModel model = new ParallelTopicModel(4, 4.0, 0.01);
+        model.setNumThreads(1);
+        model.setRandomSeed(42);
+        model.setOptimizeInterval(0);
+        model.addInstances(instances);
+        model.setNumIterations(5);
+        model.setTopicDisplay(0, 0);
+        model.printLogLikelihood = false;
+        model.estimate();
+        return model;
+    }
+
+    @Test
+    public void smoothingOnlyMassRecoversFromInjectedDriftWithinOneDocument() throws Exception {
+        ParallelTopicModel model = trainSmallModel();
+
+        WorkerCallable worker = new WorkerCallable(
+            model.numTopics, model.alpha, model.alphaSum, model.beta,
+            new FixedUniformRandoms(7), model.data, model.getTypeTopicCounts(),
+            model.getTokensPerTopic(), 0, model.data.size());
+        worker.makeOnlyThread();
+
+        // Establish a realistic baseline (cachedCoefficients for every topic, a
+        // legitimately-computed smoothingOnlyMass) the same way ParallelTopicModel does.
+        worker.call();
+
+        // Simulate the drift the bug report describes: a smoothingOnlyMass wildly
+        // inconsistent with the exact per-topic sum. Before this fix, feeding this into
+        // sampleTopicsForOneDoc -- combined with a uniform draw skewed toward the (now huge)
+        // smoothing-only bucket -- walked the smoothing-only branch past numTopics and threw
+        // ArrayIndexOutOfBoundsException reading alpha[numTopics].
+        worker.smoothingOnlyMass = 1_000_000.0;
+
+        FeatureSequence tokens = (FeatureSequence) model.data.get(0).instance.getData();
+        FeatureSequence topics = model.data.get(0).topicSequence;
+
+        worker.sampleTopicsForOneDoc(tokens, topics, true);
+
+        double exactSmoothingOnlyMass = 0.0;
+        int[] tokensPerTopic = model.getTokensPerTopic();
+        for (int topic = 0; topic < model.numTopics; topic++) {
+            exactSmoothingOnlyMass +=
+                model.alpha[topic] * model.beta / (tokensPerTopic[topic] + model.betaSum);
+        }
+
+        assertEquals(exactSmoothingOnlyMass, worker.smoothingOnlyMass, 1e-12);
+    }
+}


### PR DESCRIPTION
Part of #219 — correctness finding #6, "Unguarded array walk in the smoothing-only sampling branch".

`smoothingOnlyMass` is a running `double` updated by `+=`/`-=` as tokens are resampled, so it drifts from the exact sum over a long run. The walk that consumes it (`WorkerCallable`, and the equivalent one in `TopicInferencer`) had no bound on `newTopic`, so drift could leave `sample > 0.0` past the last topic and read `alpha[numTopics]` out of bounds — `TopicInferencer`'s copy even prints a diagnostic at that point and then does the out-of-range read anyway.

@mimno flagged this as the likely cause of "*a very hard to find problem we've known about for a long time with long-running samplers*" and asked for it to be recomputed more often.

This applies the fix suggested in the issue:
- Both walks now clamp to `numTopics - 1` instead of reading past the end.
- `WorkerCallable#sampleTopicsForOneDoc` recomputes `smoothingOnlyMass` exactly once per document (previously only once per `call()`, i.e. once per worker per iteration), bounding drift to at most one document's worth. Cost is `O(numTopics)`, negligible next to the `O(numTopics * docLength)` sampling already done per document.

Added `TestWorkerCallable` and `TestTopicInferencer` cases that inject a grossly wrong `smoothingOnlyMass` and confirm the walk clamps instead of throwing, and that the next document's sampling recomputes it exactly. The existing fixed-seed `TestParallelTopicModelRegression` still passes unchanged, confirming this doesn't alter normal-run output.
