### PR TITLE
Speed up printState: fastest GZIP level, no per-token Formatter

### DIFF
--- a/src/main/java/cc/mallet/topics/ParallelTopicModel.java
+++ b/src/main/java/cc/mallet/topics/ParallelTopicModel.java
@@ -24,16 +24,15 @@ import java.io.Serializable;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Formatter;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Logger;
+import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -1770,8 +1769,15 @@ public class ParallelTopicModel implements Serializable {
     }
     
     public void printState (File f) throws IOException {
-        PrintStream out =
-            new PrintStream(new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(f))));
+        // Level 1 (fastest) instead of the JDK's default level 6: ~11x faster to write, for a
+        //  file that's typically 15-20% larger. The state file is highly redundant text
+        //  (six repeated columns), so the extra size is a good trade, and decompressed
+        //  content is unaffected -- this only changes how hard the encoder works to shrink it.
+        GZIPOutputStream gzipOut =
+            new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(f))) {
+                { def.setLevel(Deflater.BEST_SPEED); }
+            };
+        PrintStream out = new PrintStream(gzipOut);
         printState(out);
         out.close();
     }
@@ -1786,6 +1792,17 @@ public class ParallelTopicModel implements Serializable {
         out.println();
         out.println("#beta : " + beta);
 
+        // alphabet.lookupObject(type) re-resolves the same handful of vocabulary strings for
+        //  every token; resolving each once here and reusing a single StringBuilder (instead of
+        //  a per-document Formatter, which re-parses "%d %s %d %d %s %d\n" and boxes all six
+        //  arguments for every token) is the bulk of this method's cost on a large state file.
+        String[] typeStrings = new String[alphabet.size()];
+        for (int type = 0; type < typeStrings.length; type++) {
+            typeStrings[type] = alphabet.lookupObject(type).toString();
+        }
+
+        StringBuilder output = new StringBuilder();
+
         for (int doc = 0; doc < data.size(); doc++) {
             FeatureSequence tokenSequence =    (FeatureSequence) data.get(doc).instance.getData();
             LabelSequence topicSequence =    (LabelSequence) data.get(doc).topicSequence;
@@ -1796,22 +1813,18 @@ public class ParallelTopicModel implements Serializable {
                 source = data.get(doc).instance.getSource().toString();
             }
 
-            Formatter output = new Formatter(new StringBuilder(), Locale.US);
+            output.setLength(0);
 
             for (int pi = 0; pi < topicSequence.getLength(); pi++) {
                 int type = tokenSequence.getIndexAtPosition(pi);
                 int topic = topicSequence.getIndexAtPosition(pi);
 
-                output.format("%d %s %d %d %s %d\n", doc, source, pi, type, alphabet.lookupObject(type), topic);
-
-                /*
-                out.print(doc); out.print(' ');
-                out.print(source); out.print(' '); 
-                out.print(pi); out.print(' ');
-                out.print(type); out.print(' ');
-                out.print(alphabet.lookupObject(type)); out.print(' ');
-                out.print(topic); out.println();
-                */
+                output.append(doc).append(' ')
+                    .append(source).append(' ')
+                    .append(pi).append(' ')
+                    .append(type).append(' ')
+                    .append(typeStrings[type]).append(' ')
+                    .append(topic).append('\n');
             }
 
             out.print(output);

--- a/src/test/java/cc/mallet/topics/TestParallelTopicModelPrintState.java
+++ b/src/test/java/cc/mallet/topics/TestParallelTopicModelPrintState.java
@@ -1,0 +1,154 @@
+package cc.mallet.topics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.Test;
+
+import cc.mallet.pipe.CharSequence2TokenSequence;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.pipe.SerialPipes;
+import cc.mallet.pipe.TokenSequence2FeatureSequence;
+import cc.mallet.pipe.TokenSequenceLowercase;
+import cc.mallet.pipe.iterator.StringArrayIterator;
+import cc.mallet.types.FeatureSequence;
+import cc.mallet.types.InstanceList;
+import cc.mallet.types.LabelSequence;
+
+/**
+ * Regression tests for https://github.com/mimno/Mallet/issues/219, performance finding #1
+ * (printState). The per-token java.util.Formatter was replaced with a pre-resolved String[]
+ * of vocabulary strings and direct StringBuilder appends, and the GZIP output now uses
+ * Deflater.BEST_SPEED instead of the JDK's default level. Both are meant to be
+ * performance-only changes: the decompressed content must be byte-for-byte the same text the
+ * old implementation produced.
+ */
+public class TestParallelTopicModelPrintState {
+
+    private static final String[] DOCUMENTS = new String[] {
+        "cat dog cat bird dog cat fish bird cat dog",
+        "soup pasta bread soup cheese pasta bread soup cheese",
+        "guitar drum piano guitar violin drum piano guitar",
+        "dog cat fish dog bird cat dog fish bird cat",
+    };
+
+    private static ParallelTopicModel trainModel(String[] corpus, int numIterations) throws Exception {
+        ArrayList<Pipe> pipes = new ArrayList<Pipe>();
+        pipes.add(new CharSequence2TokenSequence());
+        pipes.add(new TokenSequenceLowercase());
+        pipes.add(new TokenSequence2FeatureSequence());
+
+        InstanceList instances = new InstanceList(new SerialPipes(pipes));
+        instances.addThruPipe(new StringArrayIterator(corpus));
+
+        ParallelTopicModel model = new ParallelTopicModel(4, 4.0, 0.01);
+        model.setNumThreads(1);
+        model.setRandomSeed(42);
+        model.setOptimizeInterval(0);
+        model.addInstances(instances);
+        model.setNumIterations(numIterations);
+        model.setTopicDisplay(0, 0);
+        model.printLogLikelihood = false;
+        model.estimate();
+        return model;
+    }
+
+    // Mirrors printState's own format, independently, from the same public model state --
+    // so the test doesn't just check the method against itself.
+    private static List<String> expectedLines(ParallelTopicModel model) {
+        List<String> lines = new ArrayList<String>();
+        lines.add("#doc source pos typeindex type topic");
+
+        StringBuilder alphaLine = new StringBuilder("#alpha : ");
+        for (int topic = 0; topic < model.numTopics; topic++) {
+            alphaLine.append(model.alpha[topic]).append(' ');
+        }
+        lines.add(alphaLine.toString());
+        lines.add("#beta : " + model.beta);
+
+        for (int doc = 0; doc < model.data.size(); doc++) {
+            FeatureSequence tokens = (FeatureSequence) model.data.get(doc).instance.getData();
+            LabelSequence topics = model.data.get(doc).topicSequence;
+
+            String source = model.data.get(doc).instance.getSource() != null
+                ? model.data.get(doc).instance.getSource().toString() : "NA";
+
+            for (int pi = 0; pi < topics.getLength(); pi++) {
+                int type = tokens.getIndexAtPosition(pi);
+                int topic = topics.getIndexAtPosition(pi);
+                lines.add(doc + " " + source + " " + pi + " " + type + " "
+                    + model.alphabet.lookupObject(type) + " " + topic);
+            }
+        }
+        return lines;
+    }
+
+    private static List<String> readGzipLines(File f) throws IOException {
+        List<String> lines = new ArrayList<String>();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new GZIPInputStream(new FileInputStream(f))))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lines.add(line);
+            }
+        }
+        return lines;
+    }
+
+    @Test
+    public void decompressedContentMatchesExpectedFormat() throws Exception {
+        ParallelTopicModel model = trainModel(DOCUMENTS, 20);
+
+        File stateFile = File.createTempFile("mallet-print-state-test", ".gz");
+        stateFile.deleteOnExit();
+        model.printState(stateFile);
+
+        assertEquals(expectedLines(model), readGzipLines(stateFile));
+    }
+
+    @Test
+    public void usesFastestDeflateLevelInsteadOfDefault() throws Exception {
+        // Needs to be big enough for the level 1 vs. level 6 size difference to be
+        // unambiguous rather than lost in fixed GZIP header/footer overhead.
+        String[] biggerCorpus = new String[400];
+        for (int i = 0; i < biggerCorpus.length; i++) {
+            biggerCorpus[i] = DOCUMENTS[i % DOCUMENTS.length];
+        }
+        ParallelTopicModel model = trainModel(biggerCorpus, 5);
+
+        File stateFile = File.createTempFile("mallet-print-state-test", ".gz");
+        stateFile.deleteOnExit();
+        model.printState(stateFile);
+
+        StringBuilder text = new StringBuilder();
+        for (String line : expectedLines(model)) {
+            text.append(line).append('\n');
+        }
+        byte[] rawBytes = text.toString().getBytes("UTF-8");
+
+        ByteArrayOutputStream defaultLevelBytes = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(defaultLevelBytes)) {
+            gzip.write(rawBytes);
+        }
+
+        // Level 1 trades size for speed, so compressing the identical text should produce a
+        // larger file than the JDK's default level 6 -- that trade is the whole point of this
+        // change.
+        assertTrue(
+            "expected printState's file (" + stateFile.length() +
+                " bytes) to be larger than default-level compression (" +
+                defaultLevelBytes.size() + " bytes)",
+            stateFile.length() > defaultLevelBytes.size());
+    }
+}


### PR DESCRIPTION
Part of #219 — performance finding #1, `printState`.

@mimno singled this one out: "*The state output update seems more significant.*" The report measured `--output-state` at 14.7x slower than it needs to be, from two independent causes:

1. `GZIPOutputStream` defaults to deflate level 6. Level 1 (`Deflater.BEST_SPEED`) is ~11x faster to write, for a file that's typically 15-20% larger. The state file is a highly redundant, six-column text format, so trading size for write speed is an easy call — this only changes how hard the encoder works, decompressed content is unaffected.
2. `printState` allocated a `java.util.Formatter` per document and re-parsed a six-argument format string for every token, boxing all six arguments and re-resolving `alphabet.lookupObject(type)` each time even though the same handful of vocabulary strings repeat constantly. Replaced with a `String[]` of vocabulary strings resolved once up front and direct `StringBuilder` appends, reused across documents.

Both are performance-only changes. Added `TestParallelTopicModelPrintState`: one test decompresses `printState`'s output and compares it, line for line, against an expected format computed independently from the model's own data — confirming the content is unchanged. A second test confirms the file is actually larger than default-level compression of the same text, confirming level 1 is really in effect.
