### PR TITLE
Reset shouldSaveState after use; clamp numThreads to corpus size

### DIFF
--- a/src/main/java/cc/mallet/topics/ParallelTopicModel.java
+++ b/src/main/java/cc/mallet/topics/ParallelTopicModel.java
@@ -644,6 +644,19 @@ public class ParallelTopicModel implements Serializable {
 
         long startTime = System.currentTimeMillis();
 
+        if (numThreads > data.size()) {
+            // docsPerThread = data.size() / numThreads below would be 0, so every thread but
+            //  the last would get zero documents while the last took the entire corpus --
+            //  correct, since the empty threads contribute all-zero counts to the merge, but
+            //  silently serialized and still paying for numThreads full copies of
+            //  typeTopicCounts.
+            int reducedThreads = Math.max(1, data.size());
+            logger.warning("numThreads (" + numThreads + ") is greater than the number of " +
+                           "documents (" + data.size() + "); using " + reducedThreads +
+                           " thread" + (reducedThreads == 1 ? "" : "s") + " instead.");
+            numThreads = reducedThreads;
+        }
+
         WorkerCallable[] callables = new WorkerCallable[numThreads];
 
         @Var

--- a/src/main/java/cc/mallet/topics/WorkerCallable.java
+++ b/src/main/java/cc/mallet/topics/WorkerCallable.java
@@ -272,7 +272,13 @@ public class WorkerCallable implements Callable<Integer> {
             
             changed += sampleTopicsForOneDoc (tokenSequence, topicSequence, true);
         }
-        
+
+        // collectAlphaStatistics() arms this for exactly the call() that just ran. Without
+        //  resetting it here, once hyperparameter optimization starts collecting, every
+        //  subsequent call() also accumulates into docLengthCounts/topicDocCounts instead of
+        //  only every saveSampleInterval-th one, silently defeating the intended thinning.
+        shouldSaveState = false;
+
         if (shouldBuildLocalCounts) {
             buildLocalTypeTopicCounts();
         }

--- a/src/test/java/cc/mallet/topics/TestParallelTopicModelNumThreadsGuard.java
+++ b/src/test/java/cc/mallet/topics/TestParallelTopicModelNumThreadsGuard.java
@@ -1,0 +1,69 @@
+package cc.mallet.topics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import cc.mallet.pipe.CharSequence2TokenSequence;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.pipe.SerialPipes;
+import cc.mallet.pipe.TokenSequence2FeatureSequence;
+import cc.mallet.pipe.TokenSequenceLowercase;
+import cc.mallet.pipe.iterator.StringArrayIterator;
+import cc.mallet.types.InstanceList;
+import cc.mallet.types.LabelSequence;
+
+/**
+ * Regression test for https://github.com/mimno/Mallet/issues/219, robustness finding
+ * "numThreads > numDocs silently serialises the run": ParallelTopicModel#estimate computed
+ * docsPerThread = data.size() / numThreads, which is 0 whenever numThreads exceeds the
+ * corpus size, so every thread but the last got zero documents while the last took the
+ * entire corpus -- correct, but with all parallelism lost and numThreads full copies of
+ * typeTopicCounts still allocated regardless. estimate() now clamps numThreads to the
+ * corpus size (with a log warning) before allocating any of that.
+ */
+public class TestParallelTopicModelNumThreadsGuard {
+
+    private static final String[] DOCUMENTS = new String[] {
+        "cat dog cat bird dog",
+        "soup pasta bread soup cheese",
+        "guitar drum piano guitar violin",
+    };
+
+    @Test
+    public void numThreadsIsClampedToCorpusSize() throws Exception {
+        ArrayList<Pipe> pipes = new ArrayList<Pipe>();
+        pipes.add(new CharSequence2TokenSequence());
+        pipes.add(new TokenSequenceLowercase());
+        pipes.add(new TokenSequence2FeatureSequence());
+
+        InstanceList instances = new InstanceList(new SerialPipes(pipes));
+        instances.addThruPipe(new StringArrayIterator(DOCUMENTS));
+
+        ParallelTopicModel model = new ParallelTopicModel(4, 4.0, 0.01);
+        model.setNumThreads(16); // far more threads than the 3-document corpus below
+        model.setRandomSeed(42);
+        model.setOptimizeInterval(0);
+        model.addInstances(instances);
+        model.setNumIterations(5);
+        model.setTopicDisplay(0, 0);
+        model.printLogLikelihood = false;
+
+        model.estimate();
+
+        assertEquals(DOCUMENTS.length, model.numThreads);
+
+        // Not just "didn't crash": every token should still have a valid topic assignment,
+        // confirming the clamped run actually produced a coherent model.
+        for (int doc = 0; doc < model.data.size(); doc++) {
+            LabelSequence topics = model.data.get(doc).topicSequence;
+            for (int pi = 0; pi < topics.getLength(); pi++) {
+                int topic = topics.getIndexAtPosition(pi);
+                assertTrue(topic >= 0 && topic < model.numTopics);
+            }
+        }
+    }
+}

--- a/src/test/java/cc/mallet/topics/TestWorkerCallable.java
+++ b/src/test/java/cc/mallet/topics/TestWorkerCallable.java
@@ -1,0 +1,92 @@
+package cc.mallet.topics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import cc.mallet.pipe.CharSequence2TokenSequence;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.pipe.SerialPipes;
+import cc.mallet.pipe.TokenSequence2FeatureSequence;
+import cc.mallet.pipe.TokenSequenceLowercase;
+import cc.mallet.pipe.iterator.StringArrayIterator;
+import cc.mallet.types.InstanceList;
+import cc.mallet.util.Randoms;
+
+/**
+ * Regression test for https://github.com/mimno/Mallet/issues/219, correctness finding #5:
+ * shouldSaveState is armed by collectAlphaStatistics() for exactly the call() that follows,
+ * but nothing ever reset it back to false afterward, so every subsequent call() also
+ * accumulated into docLengthCounts/topicDocCounts instead of only every saveSampleInterval-th
+ * one. WorkerCallable#call() now resets shouldSaveState after the armed pass uses it.
+ */
+public class TestWorkerCallable {
+
+    private static final String[] DOCUMENTS = new String[] {
+        "cat dog cat bird dog cat fish bird cat dog",
+        "soup pasta bread soup cheese pasta bread soup cheese",
+        "guitar drum piano guitar violin drum piano guitar",
+        "dog cat fish dog bird cat dog fish bird cat",
+    };
+
+    private static ParallelTopicModel trainSmallModel() throws Exception {
+        ArrayList<Pipe> pipes = new ArrayList<Pipe>();
+        pipes.add(new CharSequence2TokenSequence());
+        pipes.add(new TokenSequenceLowercase());
+        pipes.add(new TokenSequence2FeatureSequence());
+
+        InstanceList instances = new InstanceList(new SerialPipes(pipes));
+        instances.addThruPipe(new StringArrayIterator(DOCUMENTS));
+
+        ParallelTopicModel model = new ParallelTopicModel(4, 4.0, 0.01);
+        model.setNumThreads(1);
+        model.setRandomSeed(42);
+        model.setOptimizeInterval(0);
+        model.addInstances(instances);
+        model.setNumIterations(5);
+        model.setTopicDisplay(0, 0);
+        model.printLogLikelihood = false;
+        model.estimate();
+        return model;
+    }
+
+    @Test
+    public void shouldSaveStateResetsAfterOneCall() throws Exception {
+        ParallelTopicModel model = trainSmallModel();
+
+        WorkerCallable worker = new WorkerCallable(
+            model.numTopics, model.alpha, model.alphaSum, model.beta,
+            new Randoms(11), model.data, model.getTypeTopicCounts(),
+            model.getTokensPerTopic(), 0, model.data.size());
+        worker.makeOnlyThread();
+        worker.initializeAlphaStatistics(20);
+
+        // Arms shouldSaveState for exactly the call() that follows -- mirrors
+        // ParallelTopicModel calling collectAlphaStatistics() only on optimization
+        // iterations.
+        worker.collectAlphaStatistics();
+        worker.call();
+
+        int totalAfterFirstCall = sum(worker.getDocLengthCounts());
+        assertTrue("the armed call() should have recorded at least one document",
+            totalAfterFirstCall > 0);
+
+        // Not re-armed: before this fix, shouldSaveState stayed true forever once set, so
+        // this second, unarmed call() would double the histogram instead of leaving it
+        // unchanged.
+        worker.call();
+
+        assertEquals(totalAfterFirstCall, sum(worker.getDocLengthCounts()));
+    }
+
+    private static int sum(int[] values) {
+        int total = 0;
+        for (int value : values) {
+            total += value;
+        }
+        return total;
+    }
+}


### PR DESCRIPTION
Part of #219 — correctness finding #5 and the robustness finding about `numThreads > numDocs`. Two small, independent fixes.

**1. `shouldSaveState` is never reset, so `saveSampleInterval` is a dead knob.**
`collectAlphaStatistics()` arms `WorkerCallable` to collect `docLengthCounts`/`topicDocCounts` for the next `call()`. `WorkerRunnable` and `DMRCallable` both clear the flag at the end of their run; `WorkerCallable` — the class that replaced `WorkerRunnable` and the one `ParallelTopicModel` actually uses — never did. Once hyperparameter optimization starts collecting, every subsequent iteration kept accumulating instead of only every `saveSampleInterval`-th one, silently turning the intended thinned samples into one long, highly autocorrelated run. Now reset at the end of `call()`, after the armed pass has used it.

**2. `numThreads > numDocs` silently serializes the run.**
`estimate()` computed `docsPerThread = data.size() / numThreads`, which is 0 whenever `numThreads` exceeds the corpus size, so every thread but the last got zero documents while the last took the entire corpus. Output stayed correct (empty workers contribute all-zero counts to the merge), but with all parallelism lost and `numThreads` full copies of `typeTopicCounts` allocated regardless. `estimate()` now clamps `numThreads` to the corpus size, with a log warning, before any of that allocation happens.

Added `TestWorkerCallable#shouldSaveStateResetsAfterOneCall` (arms the flag, calls `call()` twice, confirms the histogram total after the second, unarmed call matches the first instead of doubling) and `TestParallelTopicModelNumThreadsGuard` (trains a 3-document corpus with `numThreads=16`, confirms it's clamped to 3 and the run still produces valid topic assignments).
