### PR TITLE
Give each worker thread its own RNG seed, deterministically

### DIFF
--- a/src/main/java/cc/mallet/topics/ParallelTopicModel.java
+++ b/src/main/java/cc/mallet/topics/ParallelTopicModel.java
@@ -28,6 +28,7 @@ import java.util.Formatter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.SplittableRandom;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -640,6 +641,25 @@ public class ParallelTopicModel implements Serializable {
         
     }
 
+    /**
+     *  Derives one worker seed per thread from a single base seed, deterministically: the
+     *  same baseSeed and numThreads always produce the same seeds, in the same order, so a
+     *  training run's reproducibility for a fixed --random-seed and --num-threads does not
+     *  depend on workers sharing a seed. A plain {@code baseSeed + thread} was considered and
+     *  rejected: java.util.Random's LCG has weak low-order bits, so seeds that are close
+     *  together do not reliably decorrelate over a short stream. SplittableRandom exists
+     *  specifically to mint well-mixed sub-seeds from one seed, so it is used here purely as
+     *  a seed generator, not as the sampler's RNG.
+     */
+    static int[] deriveWorkerSeeds(int baseSeed, int numThreads) {
+        SplittableRandom seedGenerator = new SplittableRandom(baseSeed);
+        int[] seeds = new int[numThreads];
+        for (int thread = 0; thread < numThreads; thread++) {
+            seeds[thread] = seedGenerator.nextInt();
+        }
+        return seeds;
+    }
+
     public void estimate () throws IOException {
 
         long startTime = System.currentTimeMillis();
@@ -652,29 +672,37 @@ public class ParallelTopicModel implements Serializable {
         int offset = 0;
 
         if (numThreads > 1) {
-        
+
+            // Every thread used to be seeded with the same randomSeed, so with a fixed seed
+            //  all workers drew an identical stream of uniforms; deriveWorkerSeeds gives each
+            //  one its own, still deterministically from randomSeed and numThreads alone, so a
+            //  run with a fixed --random-seed and --num-threads remains exactly reproducible.
+            //  (Only matters when randomSeed is set -- the unseeded branch below already draws
+            //  fresh entropy per thread.)
+            int[] workerSeeds = (randomSeed == -1) ? null : deriveWorkerSeeds(randomSeed, numThreads);
+
             for (int thread = 0; thread < numThreads; thread++) {
                 int[] callableTotals = new int[numTopics];
                 System.arraycopy(tokensPerTopic, 0, callableTotals, 0, numTopics);
-                
+
                 int[][] callableCounts = new int[numTypes][];
                 for (int type = 0; type < numTypes; type++) {
                     int[] counts = new int[typeTopicCounts[type].length];
                     System.arraycopy(typeTopicCounts[type], 0, counts, 0, counts.length);
                     callableCounts[type] = counts;
                 }
-                
+
                 // some docs may be missing at the end due to integer division
                 if (thread == numThreads - 1) {
                     docsPerThread = data.size() - offset;
                 }
-                
+
                 Randoms random;
                 if (randomSeed == -1) {
                     random = new Randoms();
                 }
                 else {
-                    random = new Randoms(randomSeed);
+                    random = new Randoms(workerSeeds[thread]);
                 }
 
                 callables[thread] = new WorkerCallable(numTopics,

--- a/src/test/java/cc/mallet/topics/TestParallelTopicModelWorkerSeeds.java
+++ b/src/test/java/cc/mallet/topics/TestParallelTopicModelWorkerSeeds.java
@@ -1,0 +1,100 @@
+package cc.mallet.topics;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import cc.mallet.pipe.CharSequence2TokenSequence;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.pipe.SerialPipes;
+import cc.mallet.pipe.TokenSequence2FeatureSequence;
+import cc.mallet.pipe.TokenSequenceLowercase;
+import cc.mallet.pipe.iterator.StringArrayIterator;
+import cc.mallet.types.InstanceList;
+
+/**
+ * Regression tests for https://github.com/mimno/Mallet/issues/219, correctness finding #1
+ * ("every worker thread gets the same RNG seed"). mimno's specific follow-up question on the
+ * issue -- "Is the run still deterministic over multiple workers with this change? That's
+ * the part that people will care about." -- is what these tests are meant to answer with
+ * evidence, not just argument.
+ *
+ * Scope note, per the later discussion on #219: the original report's claim that per-worker
+ * seeding *improves* model quality did not hold up under a corrected (unpaired) significance
+ * test once mimno pushed back on it. This change is kept purely as hygiene -- it removes a
+ * real, measured loss of independence between workers -- not as a quality fix; each draw was
+ * already a valid sample from its own conditional either way.
+ */
+public class TestParallelTopicModelWorkerSeeds {
+
+    @Test
+    public void derivedSeedsAreDeterministic() {
+        int[] first = ParallelTopicModel.deriveWorkerSeeds(42, 8);
+        int[] second = ParallelTopicModel.deriveWorkerSeeds(42, 8);
+        assertArrayEquals(first, second);
+    }
+
+    @Test
+    public void derivedSeedsDifferPerThread() {
+        int[] seeds = ParallelTopicModel.deriveWorkerSeeds(42, 8);
+
+        Set<Integer> distinct = new HashSet<Integer>();
+        for (int seed : seeds) {
+            distinct.add(seed);
+        }
+        assertEquals("all per-worker seeds should be distinct from each other",
+            seeds.length, distinct.size());
+    }
+
+    private static final String[] DOCUMENTS = new String[] {
+        "cat dog cat bird dog cat fish bird cat dog",
+        "soup pasta bread soup cheese pasta bread soup cheese",
+        "guitar drum piano guitar violin drum piano guitar",
+        "dog cat fish dog bird cat dog fish bird cat",
+        "pasta cheese bread pasta soup cheese bread pasta soup",
+        "piano violin guitar piano drum violin piano guitar drum",
+        "cat bird fish cat dog bird cat fish dog cat",
+        "cheese soup pasta cheese bread soup pasta cheese bread",
+    };
+
+    private static ParallelTopicModel trainMultiThreaded() throws Exception {
+        ArrayList<Pipe> pipes = new ArrayList<Pipe>();
+        pipes.add(new CharSequence2TokenSequence());
+        pipes.add(new TokenSequenceLowercase());
+        pipes.add(new TokenSequence2FeatureSequence());
+
+        InstanceList instances = new InstanceList(new SerialPipes(pipes));
+        instances.addThruPipe(new StringArrayIterator(DOCUMENTS));
+
+        ParallelTopicModel model = new ParallelTopicModel(4, 4.0, 0.01);
+        model.setNumThreads(4);
+        model.setRandomSeed(42);
+        model.setOptimizeInterval(0);
+        model.addInstances(instances);
+        model.setNumIterations(50);
+        model.setTopicDisplay(0, 0);
+        model.printLogLikelihood = false;
+        model.estimate();
+        return model;
+    }
+
+    @Test
+    public void fixedSeedAndThreadCountReproducesIdenticalMultiThreadedRuns() throws Exception {
+        // The exact property mimno asked about: with a fixed --random-seed and a fixed
+        // --num-threads > 1, does re-running give the same answer? Nothing in this codebase
+        // tested multi-threaded determinism before this fix -- the existing fixed-seed
+        // regression test (TestParallelTopicModelRegression) pins numThreads=1 only.
+        ParallelTopicModel first = trainMultiThreaded();
+        ParallelTopicModel second = trainMultiThreaded();
+
+        assertEquals(first.modelLogLikelihood(), second.modelLogLikelihood(), 0.0);
+        assertTrue(Arrays.deepEquals(first.getTypeTopicCounts(), second.getTypeTopicCounts()));
+    }
+}


### PR DESCRIPTION
Part of #219 — correctness finding #1, "every worker thread gets the same RNG seed".

`ParallelTopicModel.estimate()` constructs each thread's `Randoms` **inside** the per-thread loop with `new Randoms(randomSeed)` — the same seed for every worker, so with `--random-seed` set all workers drew an identical stream of uniforms.

@mimno's question on the issue was specifically: "*I don't think it actually matters that the workers have the same random sequence... but it does seem a little cleaner. Is the run still deterministic over multiple workers with this change?*" The follow-up discussion on the thread confirmed the coupling is real (correlated bucket decisions between workers, φ ≈ +0.29–0.35 vs ≈0.001–0.002 independent, over 6M aligned draws), but that the original claim of an LL improvement didn't hold up under a corrected significance test — so this is worth keeping as hygiene rather than a quality fix.

To answer the determinism question directly: each thread now gets a seed derived from `(randomSeed, thread)` via a new `deriveWorkerSeeds()` static method, using `SplittableRandom` purely as a seed generator (not the sampler's RNG, since a plain `randomSeed + thread` risks correlated seeds under `java.util.Random`'s LCG). `deriveWorkerSeeds` is a pure function of `(randomSeed, numThreads)`, so a fixed `--random-seed` and `--num-threads` still reproduce byte-identically. The single-thread path is untouched.

Added `TestParallelTopicModelWorkerSeeds`: `deriveWorkerSeeds` is deterministic and produces distinct seeds per thread, and — the property actually asked about — training the same 4-thread, fixed-seed configuration twice produces identical log likelihood and type-topic counts. No test in this codebase previously covered multi-threaded determinism; the existing regression test pins `numThreads=1` only.
